### PR TITLE
Forgot to add 'g' option

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -51,7 +51,7 @@ XARGSARG="-0"
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 
-while getopts "o:s:d:tnw:f" options; do
+while getopts "o:s:d:tnw:fg" options; do
 	case $options in
 		o ) OUTFILE=$OPTARG;;
 		d ) WORKDIR=$OPTARG;;


### PR DESCRIPTION
This patch adds the 'g' option to getopts.

-while getopts "o:s:d:tnw:f" options; do
+while getopts "o:s:d:tnw:fg" options; do
        case $options in
                o ) OUTFILE=$OPTARG;;
                d ) WORKDIR=$OPTARG;;
