### PR TITLE
updated to better support dash

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -111,7 +111,7 @@ cd ${WORKDIR}
 if [ x${WARNMSG} = "x" ]; then
 	: > "fragments.concat"
 else
-	echo -e "$WARNMSG" > "fragments.concat"
+	printf '%s\n' "$WARNMSG" > "fragments.concat"
 fi
 
 # find all the files in the fragments directory, sort them numerically and concat to fragments.concat in the working dir


### PR DESCRIPTION
Dash (default /bin/sh on Debian and Ubuntu) does not support 'echo -e'.  That invocation of echo is not POSIX compliant: https://bugs.launchpad.net/ubuntu/+source/dash/+bug/72167
