### PR TITLE
Fix for PE

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -14,7 +14,8 @@
 # It also copies out the concatfragments.sh file to /usr/local/bin
 class concat::setup {
     $root_group = 0
-    $concatdir = "/var/lib/puppet/concat"
+    $vardir = "/var/lib/puppet"
+    $concatdir = "$vardir/concat"
     $majorversion = regsubst($puppetversion, '^[0-9]+[.]([0-9]+)[.][0-9]+$', '\1')
 
     file{"/usr/local/bin/concatfragments.sh": 
@@ -26,11 +27,18 @@ class concat::setup {
                         default => "puppet:///modules/concat/concatfragments.sh"
                       };
 
-         $concatdir: 
+         $vardir:
             ensure => directory,
             owner  => root,
             group  => $root_group,
             mode   => 755;
+
+         $concatdir:
+            ensure   => directory,
+            owner    => root,
+            group    => $root_group,
+            mode     => 755,
+            requires => File[$vardir];
     }
 }
 


### PR DESCRIPTION
We cannot assume that /var/lib/puppet exists on every platform or install. For example Puppet Enterprise does not use /var/lib/puppet. When in doubt ensure it exists.

Thanks
Chad
