### PR TITLE
As discussed .. Make $concatdir only readable by root.

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -30,7 +30,7 @@ class concat::setup {
             ensure => directory,
             owner  => root,
             group  => $root_group,
-            mode   => 755;
+            mode   => '0750';
     }
 }
 


### PR DESCRIPTION
Since we generate some potentially sensitive files using concat, it seems wise to limit access to the concatdir to root.
