### PR TITLE
Fix for /bin/sh on Solaris.

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -80,7 +80,7 @@ if [ x${WORKDIR} = "x" ]; then
 fi
 
 # can we write to -o?
-if [ -a ${OUTFILE} ]; then
+if [ -f ${OUTFILE} ]; then
 	if [ ! -w ${OUTFILE} ]; then
 		echo "Cannot write to ${OUTFILE}"
 		exit 1


### PR DESCRIPTION
In Solaris, 'test -a' does not work in /bin/sh.  Convert to 'test -f' to play nice in all universes.

From the man page on Solaris:

```
-a file                 True if file exists. (Not  available
                         in sh.)
```
