### PR TITLE
Fix use of unqualified variable names

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -13,7 +13,7 @@
 #   - group     Owner of the file
 #   - backup    Controls the filebucketing behavior of the final file and
 #               see File type reference for its use.  Defaults to 'puppet'
-define concat::fragment($target, $content='', $source='', $order=10, $ensure = "present", $mode = 0644, $owner = $id, $group = $concat::setup::root_group, $backup = "puppet") {
+define concat::fragment($target, $content='', $source='', $order=10, $ensure = "present", $mode = 0644, $owner = $::id, $group = $concat::setup::root_group, $backup = "puppet") {
     $safe_name = regsubst($name, '/', '_', 'G')
     $safe_target_name = regsubst($target, '/', '_', 'G')
     $concatdir = $concat::setup::concatdir

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,7 +87,7 @@
 # ALIASES:
 #  - The exec can notified using Exec["concat_/path/to/file"] or Exec["concat_/path/to/directory"]
 #  - The final file can be referened as File["/path/to/file"] or File["concat_/path/to/file"]  
-define concat($mode = 0644, $owner = $id, $group = $concat::setup::root_group, $warn = "false", $force = "false", $backup = "puppet", $gnu = "true", $order="alpha") {
+define concat($mode = 0644, $owner = $::id, $group = $concat::setup::root_group, $warn = "false", $force = "false", $backup = "puppet", $gnu = "true", $order="alpha") {
     $safe_name   = regsubst($name, '/', '_', 'G')
     $concatdir   = $concat::setup::concatdir
     $version     = $concat::setup::majorversion
@@ -126,7 +126,7 @@ define concat($mode = 0644, $owner = $id, $group = $concat::setup::root_group, $
     }
 
     File{
-        owner  => $id,
+        owner  => $::id,
         group  => $group,
         mode   => $mode,
         backup => $backup
@@ -171,7 +171,7 @@ define concat($mode = 0644, $owner = $id, $group = $concat::setup::root_group, $
         unless    => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} -t ${warnflag} ${forceflag} ${orderflag} ${gnuflag}",
         command   => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} ${warnflag} ${forceflag} ${orderflag} ${gnuflag}",
     }
-    if $id == 'root' {
+    if $::id == 'root' {
       Exec["concat_${name}"]{
         user      => root,
         group     => $group,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -13,12 +13,13 @@
 #
 # It also copies out the concatfragments.sh file to /usr/local/bin
 class concat::setup {
+    $id = $::id
     $root_group = $id ? {
       root => 0,
       default => $id
     }
-    $concatdir = $concat_basedir
-    $majorversion = regsubst($puppetversion, '^[0-9]+[.]([0-9]+)[.][0-9]+$', '\1')
+    $concatdir = $::concat_basedir
+    $majorversion = regsubst($::puppetversion, '^[0-9]+[.]([0-9]+)[.][0-9]+$', '\1')
 
     file{"${concatdir}/bin/concatfragments.sh":
             owner  => $id,


### PR DESCRIPTION
Fully qualify $::id, $::puppetversion, and $::concat_basedir.
