### PR TITLE
Cleanup references to legacy /usr/local/bin/concatfragments.sh

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -7,11 +7,11 @@
 # $puppetversion should be either 24 or 25 to enable a 24 compatible
 # mode, in 24 mode you might see phantom notifies this is a side effect
 # of the method we use to clear the fragments directory.
-# 
+#
 # The regular expression below will try to figure out your puppet version
 # but this code will only work in 0.24.8 and newer.
 #
-# It also copies out the concatfragments.sh file to /usr/local/bin
+# It also copies out the concatfragments.sh file to ${concatdir}/bin
 class concat::setup {
     $id = $::id
     $root_group = $id ? {
@@ -35,6 +35,10 @@ class concat::setup {
             owner  => $id,
             group  => $root_group,
             mode   => '0750';
+
+        ## Old versions of this module used a different path.
+        '/usr/local/bin/concatfragments.sh':
+            ensure => absent;
     }
 }
 


### PR DESCRIPTION
- Zap the old copy of /usr/local/bin/concatfragments.sh.
- Fix comments to point at new location of script.
- Delete trailing whitespace.
