### PR TITLE
Fix module name to make the PMT happier

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,4 +1,4 @@
-name 'puppet-concat'
+name 'ripienaar-concat'
 version '0.1.0'
 source 'git://github.com/ripienaar/puppet-concat.git'
 author 'R.I.Pienaar'


### PR DESCRIPTION
The incorrect module name causes problems with `puppet module list`. It will report that `ripienaar-concat` is missing even though it is installed, since the module reports itself as `puppet-concat`.

```
$ sudo puppet module list
Warning: Missing dependency 'ripienaar-concat':
  'puppetlabs-glance' (v0.1.0) requires 'ripienaar-concat' (>= 0.1.0)
  'puppetlabs-keystone' (v0.1.0) requires 'ripienaar-concat' (>= 0.1.0)
/etc/puppet/modules
├── duritong-sysctl (v0.0.1)
├── puppet-concat (v0.1.0)
├── puppetlabs-apt (v0.0.4)
├── puppetlabs-glance (v0.1.0)
├── puppetlabs-horizon (v0.1.0)
├── puppetlabs-keystone (v0.1.0)
├── puppetlabs-mysql (v0.3.0)
├── puppetlabs-nova (v0.1.1)
├── puppetlabs-openstack (v0.1.0)
├── puppetlabs-rabbitmq (v2.0.1)
├── puppetlabs-stdlib (v2.3.3)
└── saz-memcached (v2.0.2)
```
