### PR TITLE
Remove spurious 'e' character.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,7 +139,7 @@ define concat(
       $forceflag = ''
     }
     default: {
-e     fail("Improper 'force' value given to concat: ${force}")
+      fail("Improper 'force' value given to concat: ${force}")
     }
   }
 


### PR DESCRIPTION
Looks like this was added in 534fd8b7a4793aed7a2f85d88772ce542785c6d0
