### PR TITLE
Include concat::setup from concat, so users don't need to

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,6 @@ their changes will be incorporated into the puppet managed motd.
 <pre>
 # class to setup basic motd, include on all nodes
 class motd {
-   include concat::setup
    $motd = "/etc/motd"
 
    concat{$motd:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,9 +43,6 @@
 # There's some regular expression magic to figure out the puppet version but
 # if you're on an older 0.24 version just set $puppetversion = 24
 #
-# Before you can use any of the concat features you should include the
-# class concat::setup somewhere on your node first.
-#
 # DETAIL:
 # We use a helper shell script called concatfragments.sh that gets placed
 # in <Puppet[:vardir]>/concat/bin to do the concatenation.  While this might
@@ -106,6 +103,8 @@ define concat(
   $gnu = undef,
   $order='alpha'
 ) {
+  include concat::setup
+
   $safe_name   = regsubst($name, '/', '_', 'G')
   $concatdir   = $concat::setup::concatdir
   $version     = $concat::setup::majorversion


### PR DESCRIPTION
This includes concat::setup directly from concat, so users don't have to.  Of course, it won't hurt to include it manually, too.

This should fix #gh-16.

I'm not sure what @dalen meant in his last comment there, about resource defaults.  I'll revise if you can clarify.
