### PR TITLE
Remove trailing whitespace to make puppet-lint happy

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -1,5 +1,5 @@
 # Puts a file fragment into a directory previous setup using concat
-# 
+#
 # OPTIONS:
 #   - target    The file that these fragments belong to
 #   - content   If present puts the content into the file


### PR DESCRIPTION
puppet-lint does not like trailing whitespaces, not even in comments
