### PR TITLE
Add puppet-lint and rspec-puppet gems to make Travis CI work again

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -2,4 +2,6 @@ source :rubygems
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
 gem 'puppet', puppetversion
+gem 'puppet-lint'
+gem 'rspec-puppet'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'


### PR DESCRIPTION
The Rakefile currently references puppet-lint and rspec-puppet without ensuring that these gems are actually installed.
Now these two gems are listed explicitly in the .gemfile to ensure there presence when running the rake tests.
