### PR TITLE
Fixes various puppet-lint warnings.

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -29,6 +29,9 @@ define concat::fragment($target, $content='', $source='', $order=10, $ensure = '
             '', 'absent', 'present', 'file', 'directory': {
               crit('No content, source or symlink specified')
             }
+            default: {
+              #do nothing, make puppet-lint happy.
+            }
           }
         }
         default: { File{ source => $source } }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -218,8 +218,8 @@ define concat(
   }
 
   file { $name:
-    path     => $path,
     ensure   => present,
+    path     => $path,
     alias    => "concat_${name}",
     group    => $group,
     mode     => $mode,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -26,15 +26,16 @@ class concat::setup {
   }
 
   $majorversion = regsubst($::puppetversion, '^[0-9]+[.]([0-9]+)[.][0-9]+$', '\1')
+  $fragments_source = $majorversion ? {
+    24      => 'puppet:///concat/concatfragments.sh',
+    default => 'puppet:///modules/concat/concatfragments.sh'
+  }
 
   file{"${concatdir}/bin/concatfragments.sh":
     owner  => $id,
     group  => $root_group,
     mode   => '0755',
-    source => $majorversion ? {
-      24      => 'puppet:///concat/concatfragments.sh',
-      default => 'puppet:///modules/concat/concatfragments.sh'
-    };
+    source => $fragments_source;
 
   [ $concatdir, "${concatdir}/bin" ]:
     ensure => directory,


### PR DESCRIPTION
- ./manifests/init.pp - WARNING: ensure found on line but it's not the first attribute on line 222
- ./manifests/setup.pp - WARNING: selector inside resource block on line 34
- ./manifests/fragment.pp - WARNING: case statement without a default case on line 28
