### PR TITLE
Style guideline fix for README example's mode

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ class motd {
    concat{$motd:
       owner => root,
       group => root,
-      mode  => 644
+      mode  => '0644',
    }
 
    concat::fragment{"motd_header":


### PR DESCRIPTION
puppet-lint reports that 644 should be '0644', per http://puppet-lint.com/checks/file_mode/
