### PR TITLE
Case don't require ',' between cases

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -26,7 +26,7 @@ define concat::fragment($target, $content=undef, $source=undef, $order=10, $ensu
       if ! ($content or $source) {
         crit('No content, source or symlink specified')
       }
-    },
+    }
     default: {
       # do nothing, make puppet-lint happy
     }


### PR DESCRIPTION
The ',' between the cases break puppet (at least in 2.6 2.7 series) with : 
Syntax error at ','; expected '}' at [...]
