### PR TITLE
Added -r flag to read so that filenames with \ will be read correctly

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -112,7 +112,7 @@ else
 fi
 
 # find all the files in the fragments directory, sort them numerically and concat to fragments.concat in the working dir
-find fragments/ -type f -follow | sort ${SORTARG} | while read fragfile; do
+find fragments/ -type f -follow | sort ${SORTARG} | while read -r fragfile; do
 	cat "$fragfile" >> "fragments.concat"
 done
 


### PR DESCRIPTION
I ran into an issue where fragment file names may include a `\`.  When concatfragments.sh was run, it was incorrectly swallowing the `\` character in the file name, causing the fragment to not be included in the final file.  This change fixes that behavior.
