### PR TITLE
Allow WARNMSG to contain/start with '#'

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -105,7 +105,7 @@ fi
 
 cd ${WORKDIR}
 
-if [ x${WARNMSG} = "x" ]; then
+if [ "x${WARNMSG}" = "x" ]; then
 	: > "fragments.concat"
 else
 	printf '%s\n' "$WARNMSG" > "fragments.concat"


### PR DESCRIPTION
Previosuly this error was being displayed:
    108: [: x#: unexpected operator

Together with the puppetlabs postgres module concatfragment failed because at [ x$WARNMSG ...]  where $WARNMSG started with an '#', which is invalid syntax.

This is the puppet agent output:

> debug: Exec[concat_/etc/postgresql/9.1/main/pg_hba.conf](provider=posix): Executing check '/var/lib/puppet/concat/bin/concatfragments.sh -o /var/lib/puppet/concat/_etc_postgresql_9.1_main_pg_hba.conf/fragments.concat.out -d /var/lib/puppet/concat/_etc_postgresql_9.1_main_pg_hba.conf -t -w '# This file is managed by Puppet. DO NOT EDIT.'  '
> debug: Executing '/var/lib/puppet/concat/bin/concatfragments.sh -o /var/lib/puppet/concat/_etc_postgresql_9.1_main_pg_hba.conf/fragments.concat.out -d /var/lib/puppet/concat/_etc_postgresql_9.1_main_pg_hba.conf -t -w '# This file is managed by Puppet. DO NOT EDIT.'  '
> debug: /Stage[main]/Postgresql::Config::Beforeservice/Postgresql::Pg_hba[main]/Concat[/etc/postgresql/9.1/main/pg_hba.conf]/Exec[concat_/etc/postgresql/9.1/main/pg_hba.conf]/unless: /var/lib/puppet/concat/bin/concatfragments.sh: 108: [: x#: unexpected operator
