### PR TITLE
sort always with LANG=C

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -112,7 +112,7 @@ else
 fi
 
 # find all the files in the fragments directory, sort them numerically and concat to fragments.concat in the working dir
-find fragments/ -type f -follow | sort ${SORTARG} | while read -r fragfile; do
+find fragments/ -type f -follow | LANG=C sort ${SORTARG} | while read -r fragfile; do
 	cat "$fragfile" >> "fragments.concat"
 done
 


### PR DESCRIPTION
somehow puppet leaks then LANG into execs (at least since I went from Puppet 2.6 to 3.1.1), which can give different ordering depending with which LANG puppet is executed. Which is likely different between a logged in admin and cron.

A question that remains, is whether this is actually a bug in puppet or not.
