### PR TITLE
use user's primary group as root_group when user is not root

### DIFF
--- a/lib/facter/concat_usergroup.rb
+++ b/lib/facter/concat_usergroup.rb
@@ -1,0 +1,8 @@
+require 'etc'
+
+Facter.add("concat_usergroup") do
+    setcode do
+        user = Etc.getpwnam(Facter.value('id'))
+        Etc.getgrgid(user.gid).name
+    end
+end

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -21,7 +21,7 @@ class concat::setup {
   $id = $::id
   $root_group = $id ? {
     root    => 0,
-    default => $id
+    default => $concat_usergroup
   }
 
   if $::concat_basedir {


### PR DESCRIPTION
Hi,

In some circumstance, user's name is not identical to its primary group. When running not by root, concat will raise the following error,

Error: /Stage[main]/Concat::Setup/File[/Users/jianingy/.puppet/var/concat]: Could not evaluate: Could not find group jianingy

(my user name was "jianingy" but my primary group's name was "staff")

This patch fix it by adding another fact "concat_usergroup" which returns the name of user's primary group and set the default value of root_group to it.

Please have a look

Thanks very much
