### PR TITLE
shell change for concatfragments.sh so it works on Solaris

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Script to concat files to a config file.
 #


### PR DESCRIPTION
Use bash as the shell for the concatfragments.sh script instead of /bin/sh so that the script works on Solaris.

Solaris's /bin/sh does not have "read -r".
