### PR TITLE
add ensure_newline

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -44,7 +44,7 @@ TEST=""
 FORCE=""
 WARN=""
 SORTARG=""
-ENSURE_NEW_LINE=""
+ENSURE_NEWLINE=""
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 
@@ -60,7 +60,7 @@ while getopts "o:s:d:tnw:fl" options; do
 		w ) WARNMSG="$OPTARG";;
 		f ) FORCE="true";;
 		t ) TEST="true";;
-		l ) ENSURE_NEW_LINE="true";;
+		l ) ENSURE_NEWLINE="true";;
 		* ) echo "Specify output file with -o and fragments directory with -d"
 		    exit 1;;
 	esac
@@ -113,7 +113,7 @@ else
 	printf '%s\n' "$WARNMSG" > "fragments.concat"
 fi
 
-if [ x${ENSURE_NEW_LINE} != x ]; then
+if [ x${ENSURE_NEWLINE} != x ]; then
 	find fragments/ -type f -follow -print0 | xargs -0 -I '{}' sh -c 'if [ -n "$(tail -c 1 < {} )" ]; then echo >> {} ; fi'
 fi
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ define concat(
   $backup = 'puppet',
   $gnu = undef,
   $order='alpha',
-  $ensure_new_line = false
+  $ensure_newline = false
 ) {
   include concat::setup
 
@@ -184,7 +184,7 @@ define concat(
     }
   }
 
-  case $ensure_new_line {
+  case $ensure_newline {
     'true', true, yes, on: {
       $newlineflag = '-l'
     }
@@ -192,7 +192,7 @@ define concat(
       $newlineflag = ''
     }
     default: {
-      fail("Improper 'ensure_new_line' value given to concat: ${ensure_new_line}")
+      fail("Improper 'ensure_newline' value given to concat: ${ensure_newline}")
     }
   }
 


### PR DESCRIPTION
We've had an issue where some files we're concatenating together have no newline at the end of the file resulting in a broken file.  This change adds $ensure_newline to the concat type so we ensure that all fragments end with a newline character. 
