### PR TITLE
*manifests/fragment.pp - including concat::setup.  

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -35,6 +35,8 @@ define concat::fragment(
     $owner = $::id,
     $group = $concat::setup::root_group,
     $backup = 'puppet') {
+
+  include concat::setup
   $safe_name = regsubst($name, '[/\n]', '_', 'GM')
   $safe_target_name = regsubst($target, '[/\n]', '_', 'GM')
   $concatdir = $concat::setup::concatdir


### PR DESCRIPTION
${concat::setup::variables} were not visible within the manifests/fragment.pp scope.  This caused $fragdir not to be set within concat::fragments, and so fragments were attempting to be created in /.  

By including concat::setup, these variables are visible. 
