### PR TITLE
Fix syntax error on puppet 2.6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,7 @@ define concat(
   $replace = true,
   $gnu = undef,
   $order='alpha',
-  $ensure_newline = false,
+  $ensure_newline = false
 ) {
   include concat::setup
 


### PR DESCRIPTION
2.6 doesn't like trailing commas in class parameters.
