### PR TITLE
Replace LANG => LC_COLLATE

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -121,7 +121,7 @@ fi
 IFS_BACKUP=$IFS
 IFS='
 '
-for fragfile in `find fragments/ -type f -follow | LANG=C sort ${SORTARG}`
+for fragfile in `find fragments/ -type f -follow | LC_ALL=C sort ${SORTARG}`
 do
     cat $fragfile >> "fragments.concat"
 done


### PR DESCRIPTION
Little bit of background: I run into the problem that `concat` module sorts differently when I run it from different console for single server. 

It turns out that `concatfragments.sh` still depends on locale (even with LANG=C). It causes annoying useless regeneration of concat target files.

`man 7 locale` can give  explanation about that

```
       1.     If there is a non-null environment variable LC_ALL, the value of
              LC_ALL is used.

       2.     If an environment variable with the same name as one of the cat-
              egories above exists and is non-null, its value is used for that
              category.

       3.     If there is a non-null environment variable LANG, the  value  of
              LANG is used.
```

In my case, first console **has** setted `LC_COLLATE` to `en_US.UTF-8` , another one doesn't. `concatfragments.sh` was executed with different actual LC_COLLATE ( first => en_US.UTF-8, second => C).
And result was different for different console.

Snippet to reproduce: 

``` puppet

        concat { '/tmp/concat':}

        concat::fragment { "concat_fragment_1.1":
            target =>  '/tmp/concat',
            content => "1\n",
        }

       concat::fragment { "concat_fragment_5.1":
            target =>  '/tmp/concat',
            content => "5.1\n",
        }

       concat::fragment { "concat_fragment_10.1":
            target =>  '/tmp/concat',
            content => "10.1\n",
        }

```
