### PR TITLE
Fix group ownership on files.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ define concat(
 
   $safe_group = $group ? {
     undef   => $concat::setup::root_group,
-    default => $safe_group,
+    default => $group,
   }
 
   case $warn {

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -106,4 +106,26 @@ describe 'concat' do
 
 end
 
+describe 'concat' do
+  let(:title) { '/etc/foo.bar' }
+  let(:params) { {
+    :group => 'something', 
+    :owner => 'someone', 
+    :mode  => '0755' 
+  } }
+  let(:facts) { {
+    :concat_basedir => '/var/lib/puppet/concat',
+    :id             => 'root',
+  } }
+
+  it do
+    should contain_file("/etc/foo.bar").with( {
+      'ensure' => 'present',
+      'owner'  => 'someone',
+      'group'  => 'something',
+      'mode'   => '0755',
+    } )
+  end
+end
+
 # vim:sw=2:ts=2:expandtab:textwidth=79


### PR DESCRIPTION
At some point, I think in cdb6d6b, files stopped getting their group ownership set to the value of the group parameter and would have it set to nil/undef instead.

I've fixed this and added a test for it.
