### PR TITLE
improve whitespace consistency + remove semicolon resource compression

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -27,21 +27,21 @@
 #
 define concat::fragment(
     $target,
-    $content=undef,
-    $source=undef,
-    $order=10,
-    $ensure = 'present',
-    $mode = '0644',
-    $owner = $::id,
-    $group = undef,
-    $backup = 'puppet'
+    $content = undef,
+    $source  = undef,
+    $order   = 10,
+    $ensure  = 'present',
+    $mode    = '0644',
+    $owner   = $::id,
+    $group   = undef,
+    $backup  = 'puppet'
 ) {
   include concat::setup
 
-  $safe_name = regsubst($name, '[/\n]', '_', 'GM')
+  $safe_name        = regsubst($name, '[/\n]', '_', 'GM')
   $safe_target_name = regsubst($target, '[/\n]', '_', 'GM')
-  $concatdir = $concat::setup::concatdir
-  $fragdir = "${concatdir}/${safe_target_name}"
+  $concatdir        = $concat::setup::concatdir
+  $fragdir          = "${concatdir}/${safe_target_name}"
 
   $safe_group = $group ? {
     undef   => $concat::setup::root_group,
@@ -61,7 +61,7 @@ define concat::fragment(
     }
   }
 
-  file{"${fragdir}/fragments/${order}_${safe_name}":
+  file { "${fragdir}/fragments/${order}_${safe_name}":
     ensure  => $ensure,
     mode    => $mode,
     owner   => $owner,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,26 +48,26 @@
 #   File["concat_/path/to/file"]
 #
 define concat(
-  $ensure = 'present',
-  $path = $name,
-  $owner = $::id,
-  $group = undef,
-  $mode = '0644',
-  $warn = false,
-  $force = false,
-  $backup = 'puppet',
-  $replace = true,
-  $gnu = undef,
-  $order='alpha',
+  $ensure         = 'present',
+  $path           = $name,
+  $owner          = $::id,
+  $group          = undef,
+  $mode           = '0644',
+  $warn           = false,
+  $force          = false,
+  $backup         = 'puppet',
+  $replace        = true,
+  $gnu            = undef,
+  $order          = 'alpha',
   $ensure_newline = false,
 ) {
   include concat::setup
 
-  $safe_name   = regsubst($name, '/', '_', 'G')
-  $concatdir   = $concat::setup::concatdir
-  $version     = $concat::setup::majorversion
-  $fragdir     = "${concatdir}/${safe_name}"
-  $concat_name = 'fragments.concat.out'
+  $safe_name            = regsubst($name, '/', '_', 'G')
+  $concatdir            = $concat::setup::concatdir
+  $version              = $concat::setup::majorversion
+  $fragdir              = "${concatdir}/${safe_name}"
+  $concat_name          = 'fragments.concat.out'
   $default_warn_message = '# This file is managed by Puppet. DO NOT EDIT.'
 
   $safe_group = $group ? {
@@ -76,10 +76,10 @@ define concat(
   }
 
   case $warn {
-    'true', true, yes, on: {
+    'true', true, 'yes', 'on': {
       $warnmsg = $default_warn_message
     }
-    'false', false, no, off: {
+    'false', false, 'no', 'off': {
       $warnmsg = ''
     }
     default: {
@@ -94,10 +94,10 @@ define concat(
   }
 
   case $force {
-    'true', true, yes, on: {
+    'true', true, 'yes', 'on': {
       $forceflag = '-f'
     }
-    'false', false, no, off: {
+    'false', false, 'no', 'off': {
       $forceflag = ''
     }
     default: {
@@ -106,10 +106,10 @@ define concat(
   }
 
   case $order {
-    numeric: {
+    'numeric': {
       $orderflag = '-n'
     }
-    alpha: {
+    'alpha': {
       $orderflag = ''
     }
     default: {
@@ -118,10 +118,10 @@ define concat(
   }
 
   case $ensure_newline {
-    'true', true, yes, on: {
+    'true', true, 'yes', 'on': {
       $newlineflag = '-l'
     }
-    'false', false, no, off: {
+    'false', false, 'no', 'off': {
       $newlineflag = ''
     }
     default: {
@@ -148,44 +148,44 @@ define concat(
     }
 
     file { "${fragdir}/fragments":
-      ensure   => directory,
-      force    => true,
-      ignore   => ['.svn', '.git', '.gitignore'],
-      notify   => Exec["concat_${name}"],
-      purge    => true,
-      recurse  => true,
-      source   => $source_real,
+      ensure  => directory,
+      force   => true,
+      ignore  => ['.svn', '.git', '.gitignore'],
+      notify  => Exec["concat_${name}"],
+      purge   => true,
+      recurse => true,
+      source  => $source_real,
     }
 
     file { "${fragdir}/fragments.concat":
-      ensure   => present,
+      ensure => present,
     }
 
     file { "${fragdir}/${concat_name}":
-      ensure   => present,
+      ensure => present,
     }
 
     file { $name:
-      ensure   => present,
-      path     => $path,
-      alias    => "concat_${name}",
-      group    => $safe_group,
-      mode     => $mode,
-      owner    => $owner,
-      source   => "${fragdir}/${concat_name}",
+      ensure => present,
+      path   => $path,
+      alias  => "concat_${name}",
+      group  => $safe_group,
+      mode   => $mode,
+      owner  => $owner,
+      source => "${fragdir}/${concat_name}",
     }
 
     exec { "concat_${name}":
-      alias       => "concat_${fragdir}",
-      command     => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} ${warnflag} ${forceflag} ${orderflag} ${newlineflag}",
-      notify      => File[$name],
-      require     => [
+      alias   => "concat_${fragdir}",
+      command => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} ${warnflag} ${forceflag} ${orderflag} ${newlineflag}",
+      notify  => File[$name],
+      require => [
         File[$fragdir],
         File["${fragdir}/fragments"],
         File["${fragdir}/fragments.concat"],
       ],
-      subscribe   => File[$fragdir],
-      unless      => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} -t ${warnflag} ${forceflag} ${orderflag} ${newlineflag}",
+      subscribe => File[$fragdir],
+      unless    => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} -t ${warnflag} ${forceflag} ${orderflag} ${newlineflag}",
     }
 
     if $::id == 'root' {
@@ -196,16 +196,19 @@ define concat(
     }
   }
   else {
-    file {
-      [ $fragdir,
-        "${fragdir}/fragments",
-        "${fragdir}/fragments.concat",
-        "${fragdir}/${concat_name}" ]:
-          ensure => absent,
-          backup => false,
-          force  => true;
-        $name:
-          ensure => absent,
+    file { [
+      $fragdir,
+      "${fragdir}/fragments",
+      "${fragdir}/fragments.concat",
+      "${fragdir}/${concat_name}"
+    ]:
+      ensure => absent,
+      backup => false,
+      force  => true,
+    }
+
+    file { $name:
+      ensure => absent,
     }
 
     exec { "concat_${name}":

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -27,7 +27,7 @@ class concat::setup {
   if $::concat_basedir {
     $concatdir = $::concat_basedir
   } else {
-    fail ("\$concat_basedir not defined. Try running again with pluginsync=true on the [master] and/or [main] section of your node's '/etc/puppet/puppet.conf'.")
+    fail ('$concat_basedir not defined. Try running again with pluginsync=true on the [master] and/or [main] section of your node\'s \'/etc/puppet/puppet.conf\'.')
   }
 
   $majorversion = regsubst($::puppetversion, '^[0-9]+[.]([0-9]+)[.][0-9]+$', '\1')
@@ -36,21 +36,23 @@ class concat::setup {
     default => 'puppet:///modules/concat/concatfragments.sh'
   }
 
-  file{"${concatdir}/bin/concatfragments.sh":
+  file { "${concatdir}/bin/concatfragments.sh":
     owner  => $id,
     group  => $root_group,
     mode   => '0755',
-    source => $fragments_source;
+    source => $fragments_source,
+  }
 
-  [ $concatdir, "${concatdir}/bin" ]:
+  file { [ $concatdir, "${concatdir}/bin" ]:
     ensure => directory,
     owner  => $id,
     group  => $root_group,
-    mode   => '0750';
+    mode   => '0750',
+  }
 
   ## Old versions of this module used a different path.
-  '/usr/local/bin/concatfragments.sh':
-    ensure => absent;
+  file { '/usr/local/bin/concatfragments.sh':
+    ensure => absent,
   }
 
 }


### PR DESCRIPTION
Per http://docs.puppetlabs.com/guides/style_guide.html#resources
resource compression with the "semicolon syntax" is now considered bad
practice.
