### PR TITLE
only backup target concat file + remove backup param from concat::fragme...

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -33,8 +33,7 @@ define concat::fragment(
     $ensure  = 'present',
     $mode    = '0644',
     $owner   = $::id,
-    $group   = undef,
-    $backup  = 'puppet'
+    $group   = undef
 ) {
   validate_absolute_path($target)
   validate_re($ensure, '^$|^present$|^absent$|^file$|^directory$')
@@ -44,7 +43,6 @@ define concat::fragment(
   validate_string($mode)
   validate_string($owner)
   validate_string($group)
-  validate_string($backup)
 
   include concat::setup
 
@@ -78,7 +76,7 @@ define concat::fragment(
     group   => $safe_group,
     source  => $source,
     content => $content,
-    backup  => $backup,
+    backup  => false,
     alias   => "concat_fragment_${name}",
     notify  => Exec["concat_${target}"]
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,8 +126,8 @@ define concat(
     owner   => $owner,
     group   => $safe_group,
     mode    => $mode,
-    backup  => $backup,
-    replace => $replace
+    replace => $replace,
+    backup  => false,
   }
 
   if $ensure == 'present' {
@@ -157,6 +157,7 @@ define concat(
       path   => $path,
       alias  => "concat_${name}",
       source => "${fragdir}/${concat_name}",
+      backup => $backup,
     }
 
     # remove extra whitespace from string interopolation to make testing easier
@@ -190,12 +191,12 @@ define concat(
       "${fragdir}/${concat_name}"
     ]:
       ensure => absent,
-      backup => false,
       force  => true,
     }
 
     file { $name:
       ensure => absent,
+      backup => $backup,
     }
 
     exec { "concat_${name}":

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -26,6 +26,10 @@ class concat::setup {
     fail ('$concat_basedir not defined. Try running again with pluginsync=true on the [master] and/or [main] section of your node\'s \'/etc/puppet/puppet.conf\'.')
   }
 
+  File {
+    backup => false,
+  }
+
   file { "${concatdir}/bin/concatfragments.sh":
     owner  => $owner,
     group  => $root_group,

--- a/spec/unit/classes/concat_setup_spec.rb
+++ b/spec/unit/classes/concat_setup_spec.rb
@@ -14,6 +14,7 @@ describe 'concat::setup', :type => :class do
         :group  => id == 'root' ? 0 : id,
         :mode   => '0755',
         :source => 'puppet:///modules/concat/concatfragments.sh',
+        :backup => false,
       })
     end
 
@@ -24,6 +25,7 @@ describe 'concat::setup', :type => :class do
           :owner  => id,
           :group  => id == 'root' ? 0 : id,
           :mode   => '0750',
+          :backup => false,
         })
       end
     end
@@ -31,6 +33,7 @@ describe 'concat::setup', :type => :class do
     it do
       should contain_file('/usr/local/bin/concatfragments.sh').with({
         :ensure => 'absent',
+        :backup => false,
       })
     end
   end

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -50,8 +50,8 @@ describe 'concat::fragment', :type => :define do
         :group   => safe_group,
         :source  => p[:source],
         :content => p[:content],
-        :backup  => p[:backup],
         :alias   => "concat_fragment_#{title}",
+        :backup  => false,
       })
     end
   end
@@ -216,24 +216,5 @@ describe 'concat::fragment', :type => :define do
       end
     end
   end # group =>
-
-  context 'backup =>' do
-    context 'apenny' do
-      it_behaves_like 'fragment', 'motd_header', {
-        :backup => 'apenny',
-        :target => '/etc/motd',
-      }
-    end
-
-    context 'false' do
-      let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp', :id => 'root' }}
-      let(:params) {{ :backup => false, :target => '/etc/motd' }}
-
-      it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /is not a string/)
-      end
-    end
-  end # backup =>
 
 end

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -33,7 +33,7 @@ describe 'concat', :type => :define do
       :owner   => p[:owner],
       :group   => p[:group],
       :mode    => p[:mode],
-      :backup  => p[:backup],
+      :backup  => false,
       :replace => p[:replace],
     }
 
@@ -80,6 +80,7 @@ describe 'concat', :type => :define do
           :path   => p[:path],
           :alias  => "concat_#{title}",
           :source => "#{fragdir}/#{concat_name}",
+          :backup => p[:backup],
         }))
       end
 
@@ -130,12 +131,7 @@ describe 'concat', :type => :define do
       it do
         should contain_file(title).with(file_defaults.merge({
           :ensure => 'absent',
-        }))
-      end
-
-      it do
-        should contain_file(title).with(file_defaults.merge({
-          :ensure => 'absent',
+          :backup => p[:backup],
         }))
       end
 


### PR DESCRIPTION
...nt

Disable filebucket backup of all file resources except for the the
target file that's being concatenated.
