### PR TITLE
remove purging of /usr/local/bin/concatfragments.sh

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -33,10 +33,4 @@ class concat::setup {
     ensure => directory,
     mode   => '0755',
   }
-
-  ## Old versions of this module used a different path.
-  file { '/usr/local/bin/concatfragments.sh':
-    ensure => absent,
-  }
-
 }

--- a/spec/unit/classes/concat_setup_spec.rb
+++ b/spec/unit/classes/concat_setup_spec.rb
@@ -24,13 +24,6 @@ describe 'concat::setup', :type => :class do
         })
       end
     end
-
-    it do
-      should contain_file('/usr/local/bin/concatfragments.sh').with({
-        :ensure => 'absent',
-        :backup => false,
-      })
-    end
   end
 
   context 'facts' do


### PR DESCRIPTION
The hard coded path of `/usr/local/bin/concatfragments.sh` hasn't been
used for "a long time" so there's no reason to carry the cleanup around
any longer.
