### PR TITLE
allow concat::fragment target param to be an arbitrary string

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -35,7 +35,7 @@ define concat::fragment(
     $group   = undef,
     $backup  = undef
 ) {
-  validate_absolute_path($target)
+  validate_string($target)
   validate_re($ensure, '^$|^present$|^absent$|^file$|^directory$')
   validate_string($content)
   validate_string($source)

--- a/spec/system/symbolic_name_spec.rb
+++ b/spec/system/symbolic_name_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_system'
+
+describe 'symbolic name' do
+  pp="
+    concat { 'not_abs_path':
+      path => '/tmp/file',
+    }
+
+    concat::fragment { '1':
+      target  => 'not_abs_path',
+      content => '1',
+      order   => '01',
+    }
+
+    concat::fragment { '2':
+      target  => 'not_abs_path',
+      content => '2',
+      order   => '02',
+    }
+  "
+
+  context puppet_apply(pp) do
+    its(:stderr) { should be_empty }
+    its(:exit_code) { should_not == 1 }
+    its(:refresh) { should be_nil }
+    its(:stderr) { should be_empty }
+    its(:exit_code) { should be_zero }
+  end
+
+  describe file('/tmp/file') do
+    it { should be_file }
+    it { should contain '1' }
+    it { should contain '2' }
+  end
+end

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -44,22 +44,30 @@ describe 'concat::fragment', :type => :define do
     end
   end
 
-  context 'target =>' do
-    context '/etc/motd' do
-      it_behaves_like 'fragment', 'motd_header', {
+  context 'title' do
+    ['0', '1', 'a', 'z'].each do |title|
+      it_behaves_like 'fragment', title, {
         :target  => '/etc/motd',
       }
     end
+  end # title
 
-    ['./etc/motd', 'etc/motd', false].each do |target|
+  context 'target =>' do
+    ['./etc/motd', 'etc/motd', 'motd_header'].each do |target|
       context target do
-        let(:title) { 'motd_header' }
-        let(:facts) {{ :concat_basedir => '/tmp' }}
-        let(:params) {{ :target => target }}
+        it_behaves_like 'fragment', target, {
+          :target  => '/etc/motd',
+        }
+      end
+    end
 
-        it 'should fail' do
-          expect { should }.to raise_error(Puppet::Error, /is not an absolute path/)
-        end
+    context 'false' do
+      let(:title) { 'motd_header' }
+      let(:facts) {{ :concat_basedir => '/tmp' }}
+      let(:params) {{ :target => false }}
+
+      it 'should fail' do
+        expect { should }.to raise_error(Puppet::Error, /is not a string/)
       end
     end
   end # target =>


### PR DESCRIPTION
Revert validation of the target param as an absolute path and allow it to be an
arbitrary string.  This is so the

```
concat { <foo>: path => ...  }
concat::fragment { ...: target => <foo> }
```

association may be symbolic as long as concat path param is specified.  This
should resolve the symbolic name regression introduced in:
https://github.com/puppetlabs/puppetlabs-concat/commit/eaf84079
