### PR TITLE
deprecate concat::fragment mode, owner, & group params

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -16,11 +16,11 @@
 # [*ensure*]
 #   Present/Absent or destination to a file to include another file
 # [*mode*]
-#   Mode for the file
+#   Deprecated
 # [*owner*]
-#   Owner of the file
+#   Deprecated
 # [*group*]
-#   Owner of the file
+#   Deprecated
 # [*backup*]
 #   Deprecated
 #
@@ -30,7 +30,7 @@ define concat::fragment(
     $source  = undef,
     $order   = 10,
     $ensure  = 'present',
-    $mode    = '0640',
+    $mode    = undef,
     $owner   = undef,
     $group   = undef,
     $backup  = undef
@@ -40,9 +40,15 @@ define concat::fragment(
   validate_string($content)
   validate_string($source)
   validate_string($order)
-  validate_string($mode)
-  validate_string($owner)
-  validate_string($group)
+  if $mode {
+    warning('The $mode parameter to concat::fragment is deprecated and has no effect')
+  }
+  if $owner {
+    warning('The $owner parameter to concat::fragment is deprecated and has no effect')
+  }
+  if $group {
+    warning('The $group parameter to concat::fragment is deprecated and has no effect')
+  }
   if $backup {
     warning('The $backup parameter to concat::fragment is deprecated and has no effect')
   }
@@ -67,11 +73,12 @@ define concat::fragment(
     }
   }
 
+  # punt on group ownership until some point in the distant future when $::gid
+  # can be relied on to be present
   file { "${fragdir}/fragments/${order}_${safe_name}":
     ensure  => $ensure,
-    mode    => $mode,
-    owner   => $owner,
-    group   => $group,
+    owner   => $::id,
+    mode    => '0640',
     source  => $source,
     content => $content,
     backup  => false,

--- a/spec/system/deprecation_warnings_spec.rb
+++ b/spec/system/deprecation_warnings_spec.rb
@@ -26,6 +26,45 @@ describe 'deprecation warnings' do
     it_behaves_like 'has_warning', pp, w
   end
 
+  context 'concat::fragment mode parameter' do
+    pp="
+      concat { '/tmp/file': }
+      concat::fragment { 'foo':
+        target => '/tmp/file',
+        mode   => 'bar',
+      }
+    "
+    w = 'The $mode parameter to concat::fragment is deprecated and has no effect'
+
+    it_behaves_like 'has_warning', pp, w
+  end
+
+  context 'concat::fragment owner parameter' do
+    pp="
+      concat { '/tmp/file': }
+      concat::fragment { 'foo':
+        target => '/tmp/file',
+        owner  => 'bar',
+      }
+    "
+    w = 'The $owner parameter to concat::fragment is deprecated and has no effect'
+
+    it_behaves_like 'has_warning', pp, w
+  end
+
+  context 'concat::fragment group parameter' do
+    pp="
+      concat { '/tmp/file': }
+      concat::fragment { 'foo':
+        target => '/tmp/file',
+        group  => 'bar',
+      }
+    "
+    w = 'The $group parameter to concat::fragment is deprecated and has no effect'
+
+    it_behaves_like 'has_warning', pp, w
+  end
+
   context 'concat::fragment backup parameter' do
     pp="
       concat { '/tmp/file': }

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -10,19 +10,16 @@ describe 'concat::fragment', :type => :define do
       :source  => nil,
       :order   => 10,
       :ensure  => 'present',
-      :mode    => '0640',
-      :owner   => nil,
-      :group   => nil,
-      :backup  => 'puppet',
     }.merge(params)
 
     safe_name        = title.gsub(/[\/\n]/, '_')
     safe_target_name = p[:target].gsub(/[\/\n]/, '_')
     concatdir        = '/var/lib/puppet/concat'
     fragdir          = "#{concatdir}/#{safe_target_name}"
+    id               = 'root'
 
     let(:title) { title }
-    let(:facts) {{ :concat_basedir => concatdir }}
+    let(:facts) {{ :concat_basedir => concatdir, :id => id }}
     let(:params) { params }
     let(:pre_condition) do
       "concat{ '#{p[:target]}': }"
@@ -33,9 +30,8 @@ describe 'concat::fragment', :type => :define do
       should contain_concat(p[:target])
       should contain_file("#{fragdir}/fragments/#{p[:order]}_#{safe_name}").with({
         :ensure  => p[:ensure],
-        :mode    => p[:mode],
-        :owner   => p[:owner],
-        :group   => p[:group],
+        :owner   => id,
+        :mode    => '0640',
         :source  => p[:source],
         :content => p[:content],
         :alias   => "concat_fragment_#{title}",
@@ -156,72 +152,58 @@ describe 'concat::fragment', :type => :define do
     end
   end # order =>
 
-  context 'mode =>' do
-    context '1755' do
-      it_behaves_like 'fragment', 'motd_header', {
-        :mode => '1755',
-        :target => '/etc/motd',
-      }
-    end
+  describe 'deprecated parameter' do
+    context 'mode =>' do
+      context '1755' do
+        it_behaves_like 'fragment', 'motd_header', {
+          :mode   => '1755',
+          :target => '/etc/motd',
+        }
 
-    context 'false' do
-      let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp' }}
-      let(:params) {{ :mode => false, :target => '/etc/motd' }}
-
-      it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /is not a string/)
+        it 'should create a warning' do
+          pending('rspec-puppet support for testing warning()')
+        end
       end
-    end
-  end # mode =>
+    end # mode =>
 
-  context 'owner =>' do
-    context 'apenny' do
-      it_behaves_like 'fragment', 'motd_header', {
-        :owner => 'apenny',
-        :target => '/etc/motd',
-      }
-    end
+    context 'owner =>' do
+      context 'apenny' do
+        it_behaves_like 'fragment', 'motd_header', {
+          :owner  => 'apenny',
+          :target => '/etc/motd',
+        }
 
-    context 'false' do
-      let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp' }}
-      let(:params) {{ :owner => false, :target => '/etc/motd' }}
-
-      it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /is not a string/)
+        it 'should create a warning' do
+          pending('rspec-puppet support for testing warning()')
+        end
       end
-    end
-  end # owner =>
+    end # owner =>
 
-  context 'group =>' do
-    context 'apenny' do
-      it_behaves_like 'fragment', 'motd_header', {
-        :group => 'apenny',
-        :target => '/etc/motd',
-      }
-    end
+    context 'group =>' do
+      context 'apenny' do
+        it_behaves_like 'fragment', 'motd_header', {
+          :group  => 'apenny',
+          :target => '/etc/motd',
+        }
 
-    context 'false' do
-      let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp' }}
-      let(:params) {{ :group => false, :target => '/etc/motd' }}
-
-      it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /is not a string/)
+        it 'should create a warning' do
+          pending('rspec-puppet support for testing warning()')
+        end
       end
-    end
-  end # group =>
+    end # group =>
 
-  # should raise a warning but rspec-puppet can't presently test for warning()
-  # we can only test for the existence of the parameter
-  context 'backup =>' do
-    context 'foo' do
-      it_behaves_like 'fragment', 'motd_header', {
-        :backup => 'foo',
-        :target => '/etc/motd',
-      }
-    end
-  end # backup =>
+    context 'backup =>' do
+      context 'foo' do
+        it_behaves_like 'fragment', 'motd_header', {
+          :backup => 'foo',
+          :target => '/etc/motd',
+        }
+
+        it 'should create a warning' do
+          pending('rspec-puppet support for testing warning()')
+        end
+      end
+    end # backup =>
+  end # deprecated params
 
 end

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -367,11 +367,15 @@ describe 'concat', :type => :define do
     end
   end # ensure_newline =>
 
-  # should raise a warning but rspec-puppet can't presently test for warning()
-  # we can only test for the existence of the parameter
-  context 'gnu =>' do
-    context 'foo' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :gnu => 'foo'}
+  describe 'deprecated parameter' do
+    context 'gnu =>' do
+      context 'foo' do
+        it_behaves_like 'concat', '/etc/foo.bar', { :gnu => 'foo'}
+
+        it 'should create a warning' do
+          pending('rspec-puppet support for testing warning()')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
There's no need to allow the ownership/permissions of a fragment to be set as
the concat define sets ownership/permissions on the final aggregated file.
