### PR TITLE
[Issue_69] Prevent cat globbing if filenames contains wildcards

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -79,8 +79,8 @@ if [ x${WORKDIR} = "x" ]; then
 fi
 
 # can we write to -o?
-if [ -f ${OUTFILE} ]; then
-	if [ ! -w ${OUTFILE} ]; then
+if [ -f "${OUTFILE}" ]; then
+	if [ ! -w "${OUTFILE}" ]; then
 		echo "Cannot write to ${OUTFILE}"
 		exit 1
 	fi
@@ -121,19 +121,23 @@ fi
 IFS_BACKUP=$IFS
 IFS='
 '
-for fragfile in `find fragments/ -type f -follow | LC_ALL=C sort ${SORTARG}`
-do
-    cat $fragfile >> "fragments.concat"
-done
+(
+    # turn off file globbing as fragments found might have a wildcard in the name
+    set -f
+    for fragfile in `find fragments/ -type f -follow | LC_ALL=C sort ${SORTARG}`
+    do
+        cat "$fragfile" >> "fragments.concat"
+    done
+)
 IFS=$IFS_BACKUP
 
 if [ x${TEST} = "x" ]; then
 	# This is a real run, copy the file to outfile
-	cp fragments.concat ${OUTFILE}
+	cp fragments.concat "${OUTFILE}"
 	RETVAL=$?
 else
 	# Just compare the result to outfile to help the exec decide
-	cmp ${OUTFILE} fragments.concat
+	cmp "${OUTFILE}" fragments.concat
 	RETVAL=$?
 fi
 


### PR DESCRIPTION
I ran into the same problem as the one described, this fixed it for me.

Example:

<pre>
concat { 'test': path => '/tmp/test' }
concat::fragment { 'one-other': target => 'test', content => "one-other\n" }
concat::fragment { '*-test': target => 'test', content => "*-test\n" }
concat::fragment { 'one-test': target => 'test', content => "one-test\n" }
</pre>


This would result in the file /tmp/test containing the following:

Actual:

<pre>
one-other
*-test
one-test
one-test
one-test
</pre>


Expected:

<pre>
one-other
*-test
one-test
</pre>
