### PR TITLE
Puppet 2.6.x compatibility fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@ define concat(
   $replace        = true,
   $order          = 'alpha',
   $ensure_newline = false,
-  $gnu            = undef,
+  $gnu            = undef
 ) {
   validate_re($ensure, '^present$|^absent$')
   validate_absolute_path($path)


### PR DESCRIPTION
Removes a comma that puppet versions 2.6.x complain about, no such problems with 3.x, but as "most" distributions still use 2.6 versions might as well fix it.

Fixes:

<pre>
Error 400 on SERVER: Syntax error at ')' at /etc/puppet/modules/concat/manifests/init.pp:71
</pre>
