### PR TITLE
update travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,21 @@ rvm:
   - 2.0.0
 env:
   matrix:
+    - PUPPET_GEM_VERSION="2.7.3" FACTER_GEM_VERSION="1.6.0"
     - PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
     - PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.0"
   global:
 matrix:
   exclude:
     - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="2.7.3" FACTER_GEM_VERSION="1.6.0"
+    - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="2.7.3" FACTER_GEM_VERSION="1.6.0"
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
     - rvm: 2.0.0


### PR DESCRIPTION
- peg the oldest tested version at puppet 2.7.3 + facter 1.6.0,
  primarily to try to catch the class param dangling comma issue that
  effects older versions of puppet
- let the newest version of puppet 3.x free float
