### PR TITLE
allow source param to concat::fragment to be a string or an Array

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -38,7 +38,9 @@ define concat::fragment(
   validate_string($target)
   validate_re($ensure, '^$|^present$|^absent$|^file$|^directory$')
   validate_string($content)
-  validate_string($source)
+  if !(is_string($source) or is_array($source)) {
+    fail('$source is not a string or an Array.')
+  }
   validate_string($order)
   if $mode {
     warning('The $mode parameter to concat::fragment is deprecated and has no effect')

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -111,7 +111,7 @@ describe 'concat::fragment', :type => :define do
   end # content =>
 
   context 'source =>' do
-    ['', '/foo/bar'].each do |source|
+    ['', '/foo/bar', ['/foo/bar', '/foo/baz']].each do |source|
       context source do
         it_behaves_like 'fragment', 'motd_header', {
           :source => source,
@@ -126,7 +126,7 @@ describe 'concat::fragment', :type => :define do
       let(:params) {{ :source => false, :target => '/etc/motd' }}
 
       it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /is not a string/)
+        expect { should }.to raise_error(Puppet::Error, /is not a string or an Array/)
       end
     end
   end # source =>


### PR DESCRIPTION
This is resolve a regression preventing an array of string(s) being passed to
the fragment file resource's source parameter.
