### PR TITLE
Test concat::fragment for source => [] compatibility.

### DIFF
--- a/spec/system/fragment_list_source_spec.rb
+++ b/spec/system/fragment_list_source_spec.rb
@@ -4,8 +4,10 @@ describe 'concat::fragment source lists ' do
   context 'should create files containing first match only.' do
     file1_contents="file1 contents"
     file2_contents="file2 contents"
-    shell("echo '#{file1_contents}' > /tmp/file1")
-    shell("echo '#{file2_contents}' > /tmp/file2")
+    before(:all) do
+      shell("/bin/echo '#{file1_contents}' > /tmp/file1")
+      shell("/bin/echo '#{file2_contents}' > /tmp/file2")
+    end
     pp="
       
       concat { '/tmp/result_file1':
@@ -65,6 +67,9 @@ describe 'concat::fragment source lists ' do
   end
   
   context 'should fail if no match on source.' do
+    before(:all) do
+      shell("/bin/rm /tmp/fail_no_source /tmp/nofilehere /tmp/nothereeither")
+    end
     pp="
       concat { '/tmp/fail_no_source':
         owner   => root,
@@ -80,10 +85,13 @@ describe 'concat::fragment source lists ' do
     "
     context puppet_apply(pp) do
       its(:exit_code) { should_not be_zero }
+      its(:exit_code) { should_not == 1 }
       its(:refresh) { should be_nil }
     end
     describe file('/tmp/fail_no_source') do
-       it { should_not exist }
+       #FIXME: Serverspec::Type::File doesn't support exists? for some reason. so... hack.
+       it { should_not be_file }
+       it { should_not be_directory }
     end
  end
 end


### PR DESCRIPTION
This is ... mostly correct, I believe, but I need a nudge in the right direction for setting up test prerequisites here. either I have brain-damage (possible) or shell() calls are in a strange context that doesn't result in what I expect. This _should_ be creating /tmp/file1 and /tmp/file2 so I can do appropriate testing with them, but the puppet run can't find them and I'm not seeing output to explain their lack of existence.

I _think_ this is at the 5y line. Mind aiming me in the right direction for best practice?
