### PR TITLE
Cleanup references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@ What is it?
 A Puppet module that can construct files from fragments.
 
 Please see the comments in the various .pp files for details
-as well as posts on my blog at http://www.devco.net/
+as well as posts on [R.I.Pienaar's blog](http://www.devco.net/)
 
 Released under the Apache 2.0 licence
 
-Usage:
-------
+Usage
+-----
 
 If you wanted a /etc/motd file that listed all the major modules
 on the machine.  And that would be maintained automatically even
 if you just remove the include lines for other modules you could
 use code like below, a sample /etc/motd would be:
 
-<pre>
+```
 Puppet modules on this server:
 
     -- Apache
     -- MySQL
-</pre>
+```
 
 Local sysadmins can also append to the file by just editing /etc/motd.local
 their changes will be incorporated into the puppet managed motd.
@@ -79,8 +79,8 @@ class apache {
 Detailed documentation of the class options can be found in the
 manifest files.
 
-Known Issues:
--------------
+Known Issues
+------------
 * Since puppet-concat now relies on a fact for the concat directory,
   you will need to set up pluginsync = true on both the master and client
   node's '/etc/puppet/puppet.conf' for at least the first run.
@@ -89,75 +89,10 @@ Known Issues:
   "err: Failed to apply catalog: Parameter path failed: File
   paths must be fully qualified, not 'undef' at [...]/concat/manifests/setup.pp:44".
 
-Contributors:
--------------
-**Paul Elliot**
+Contributors
+------------
+Detailed graphs of contributions can be found on [GitHub](../../graphs/contributors)
 
- * Provided 0.24.8 support, shell warnings and empty file creation support.
-
-**Chad Netzer**
-
- * Various patches to improve safety of file operations
- * Symlink support
-
-**David Schmitt**
-
- * Patch to remove hard coded paths relying on OS path
- * Patch to use file{} to copy the resulting file to the final destination.  This means Puppet client will show diffs and that hopefully we can change file ownerships now
-
-**Peter Meier**
-
- * Basedir as a fact
- * Unprivileged user support
-
-**Sharif Nassar**
-
- * Solaris/Nexenta support
- * Better error reporting
-
-**Christian G. Warden**
-
- * Style improvements
-
-**Reid Vandewiele**
-
- * Support non GNU systems by default
-
-**Erik Dalén**
-
- * Style improvements
-
-**Gildas Le Nadan**
-
- * Documentation improvements
-
-**Paul Belanger**
-
- * Testing improvements and Travis support
-
-**Branan Purvine-Riley**
-
- * Support Puppet Module Tool better
-
-**Dustin J. Mitchell**
-
- * Always include setup when using the concat define
-
-**Andreas Jaggi**
-
- * Puppet Lint support
-
-**Jan Vansteenkiste**
-
- * Configurable paths
-
-**Joshua Hoblitt**
-
- * Remove requirement to manually include `concat::setup` in the manifest
- * Style improvements
- * Parameter validation / refactor parameter handling
- * Test coverage
-
-Contact:
---------
+Contact
+-------
 puppet-users@ mailing list.


### PR DESCRIPTION
- replace use of "my" with Author's name
- replace list of contributors with a link to the GitHub graphs wich
  track those a lot better than we can
- use ``` instread of <pre>
