### PR TITLE
Adds a noop_mode to concat::setup

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -63,6 +63,7 @@ define concat::fragment(
   $safe_target_name = regsubst($target, '[/:\n]', '_', 'GM')
   $concatdir        = $concat::setup::concatdir
   $fragdir          = "${concatdir}/${safe_target_name}"
+  $noop             = $concat::setup::noop
 
   # The file type's semantics are problematic in that ensure => present will
   # not over write a pre-existing symlink.  We are attempting to provide
@@ -107,6 +108,7 @@ define concat::fragment(
     content => $content,
     backup  => false,
     alias   => "concat_fragment_${name}",
-    notify  => Exec["concat_${target}"]
+    notify  => Exec["concat_${target}"],
+    noop    => $noop,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,7 @@ define concat(
   $concat_name          = 'fragments.concat.out'
   $script_command       = $concat::setup::script_command
   $default_warn_message = '# This file is managed by Puppet. DO NOT EDIT.'
+  $noop                 = $concat::setup::noop
 
   if $warn == true {
     $use_warn_message = $warn_message ? {
@@ -126,6 +127,11 @@ define concat(
 
   File {
     backup  => false,
+    noop    => $noop,
+  }
+
+  Exec {
+    noop    => $noop,
   }
 
   if $ensure == 'present' {
@@ -164,6 +170,7 @@ define concat(
       alias   => "concat_${name}",
       source  => "${fragdir}/${concat_name}",
       backup  => $backup,
+      noop    => $::clientnoop,
     }
 
     # remove extra whitespace from string interpolation to make testing easier
@@ -199,6 +206,7 @@ define concat(
     file { $name:
       ensure => absent,
       backup => $backup,
+      noop   => $::clientnoop,
     }
 
     $absent_exec_command = $::kernel ? {

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -9,7 +9,15 @@
 #
 # It also copies out the concatfragments.sh file to ${concatdir}/bin
 #
-class concat::setup {
+class concat::setup (
+  $noop_mode = 'strict',
+) {
+  validate_re($noop_mode, '^strict$|^friendly$')
+  $noop = $noop_mode ? {
+    'strict' => $::clientnoop,
+    'friendly' => false,
+  }
+
   if $caller_module_name != $module_name {
     warning("${name} is deprecated as a public API of the ${module_name} module and should no longer be directly included in the manifest.")
   }
@@ -34,6 +42,7 @@ class concat::setup {
 
   File {
     backup => false,
+    noop   => $noop,
   }
 
   file { $script_path:


### PR DESCRIPTION
Create a noop_mode parameter which allows the module user to elect to relax the
noop metaparameter on certain resources in the module.  Specifically, this mode
controls the noop metaparameter of every resource except for the final target
of a concat.  In 'strict' mode, all resources respect the --noop command line
argument.  In 'friendly' mode, file resources under concatdir and the execs
which cause concatenation are forced to false regardless of the --noop command
line argument.
