### PR TITLE
[Most of] variables quoted to allow multi-word warning messages, spaces ...

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -67,26 +67,26 @@ while getopts "o:s:d:tnw:fl" options; do
 done
 
 # do we have -o?
-if [ x${OUTFILE} = "x" ]; then
+if [ "x${OUTFILE}" = "x" ]; then
 	echo "Please specify an output file with -o"
 	exit 1
 fi
 
 # do we have -d?
-if [ x${WORKDIR} = "x" ]; then
+if [ "x${WORKDIR}" = "x" ]; then
 	echo "Please fragments directory with -d"
 	exit 1
 fi
 
 # can we write to -o?
-if [ -f ${OUTFILE} ]; then
-	if [ ! -w ${OUTFILE} ]; then
+if [ -f "${OUTFILE}" ]; then
+	if [ ! -w "${OUTFILE}" ]; then
 		echo "Cannot write to ${OUTFILE}"
 		exit 1
 	fi
 else
-	if [ ! -w `dirname ${OUTFILE}` ]; then
-		echo "Cannot write to `dirname ${OUTFILE}` to create ${OUTFILE}"
+	if [ ! -w `dirname "${OUTFILE}"` ]; then
+		echo "Cannot write to `dirname \"${OUTFILE}\"` to create ${OUTFILE}"
 		exit 1
 	fi
 fi
@@ -98,14 +98,14 @@ if [ ! -d "${WORKDIR}/fragments" ]  && [ ! -x "${WORKDIR}/fragments" ]; then
 fi
 
 # are there actually any fragments?
-if [ ! "$(ls -A ${WORKDIR}/fragments)" ]; then
-	if [ x${FORCE} = "x" ]; then
+if [ ! "$(ls -A \"${WORKDIR}/fragments\")" ]; then
+	if [ "x${FORCE}" = "x" ]; then
 		echo "The fragments directory is empty, cowardly refusing to make empty config files"
 		exit 1
 	fi
 fi
 
-cd ${WORKDIR}
+cd "${WORKDIR}"
 
 if [ "x${WARNMSG}" = "x" ]; then
 	: > "fragments.concat"
@@ -113,7 +113,7 @@ else
 	printf '%s\n' "$WARNMSG" > "fragments.concat"
 fi
 
-if [ x${ENSURE_NEWLINE} != x ]; then
+if [ "x${ENSURE_NEWLINE}" != "x" ]; then
 	find fragments/ -type f -follow -print0 | xargs -0 -I '{}' sh -c 'if [ -n "$(tail -c 1 < {} )" ]; then echo >> {} ; fi'
 fi
 
@@ -127,13 +127,13 @@ do
 done
 IFS=$IFS_BACKUP
 
-if [ x${TEST} = "x" ]; then
+if [ "x${TEST}" = "x" ]; then
 	# This is a real run, copy the file to outfile
-	cp fragments.concat ${OUTFILE}
+	cp fragments.concat "${OUTFILE}"
 	RETVAL=$?
 else
 	# Just compare the result to outfile to help the exec decide
-	cmp ${OUTFILE} fragments.concat
+	cmp "${OUTFILE}" fragments.concat
 	RETVAL=$?
 fi
 


### PR DESCRIPTION
...in file/directory names, etc.
