### PR TITLE
ensure that numbers are also valid as prefix

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -43,7 +43,7 @@ define concat::fragment(
   if !(is_string($source) or is_array($source)) {
     fail('$source is not a string or an Array.')
   }
-  if !(is_string($order) or is_numeric($order)) {
+  if is_bool($order) or !(is_string($order) or is_numeric($order)) {
     fail('$order is not a string nor numeric.')
   }
   if $mode {


### PR DESCRIPTION
an error occurred in this situation:

define xxx ($priority = 500) {
  ....

  $prio = $priority + 300

  concat::fragment { 'yyy':
    target  => $zzz,
    content => 'something',
    order   => $prio,
  }
}

this creates an error on the master:

puppet-master[14563]: 800 is not a string.  It looks to be a Fixnum at /etc/puppet/modules/concat/manifests/fragment.pp:46 on node proxy.local.net

I tested to replace it with:

   $prio = 800

this worked fine but an "+" expression converts it into a number.

I'm not sure if this is bad/wrong behavior within puppet but because
we allow (default value is the _number_ 10) numbers explicitely it should
not cause any type of error.

More exact information:

  Modules used:
    puppetlabs/puppetlabs-concat (63b5aba9fd8aee29ae2461d1819abc92095afc50)
    jfryman/puppet-nginx (1233413bc2142a1adeab73e5ab63ce15fc962c1f)

  Code:

```
nginx::resource::vhost { 'something.com':
  proxy                => 'http://10.0.10.204',
  rewrite_to_https     => true,
  ssl                  => true,
  ssl_cert             => '/etc/nginx/ssl/something.com.crt',
  ssl_key              => '/etc/nginx/ssl/something.com.key',
}
```

  Puppet: 3.3.2
  Ruby: 1.9.3p194
