### PR TITLE
revert concat $warn/$warn_message param split + add deprecation warnings

### DIFF
--- a/spec/system/deprecation_warnings_spec.rb
+++ b/spec/system/deprecation_warnings_spec.rb
@@ -27,6 +27,54 @@ describe 'deprecation warnings' do
     it_behaves_like 'has_warning', pp, w
   end
 
+  context 'concat warn parameter =>' do
+    ['true', 'yes', 'on'].each do |warn|
+      context warn do
+        pp = <<-EOS
+          concat { '/tmp/concat/file':
+            warn => '#{warn}',
+          }
+          concat::fragment { 'foo':
+            target  => '/tmp/concat/file',
+            content => 'bar',
+          }
+        EOS
+        w = 'Using stringified boolean values (\'true\', \'yes\', \'on\', \'false\', \'no\', \'off\') to represent boolean true/false as the $warn parameter to concat is deprecated and will be treated as the warning message in a future release'
+
+        it_behaves_like 'has_warning', pp, w
+
+        describe file('/tmp/concat/file') do
+          it { should be_file }
+          it { should contain '# This file is managed by Puppet. DO NOT EDIT.' }
+          it { should contain 'bar' }
+        end
+      end
+    end
+
+    ['false', 'no', 'off'].each do |warn|
+      context warn do
+        pp = <<-EOS
+          concat { '/tmp/concat/file':
+            warn => '#{warn}',
+          }
+          concat::fragment { 'foo':
+            target  => '/tmp/concat/file',
+            content => 'bar',
+          }
+        EOS
+        w = 'Using stringified boolean values (\'true\', \'yes\', \'on\', \'false\', \'no\', \'off\') to represent boolean true/false as the $warn parameter to concat is deprecated and will be treated as the warning message in a future release'
+
+        it_behaves_like 'has_warning', pp, w
+
+        describe file('/tmp/concat/file') do
+          it { should be_file }
+          it { should_not contain '# This file is managed by Puppet. DO NOT EDIT.' }
+          it { should contain 'bar' }
+        end
+      end
+    end
+  end
+
   context 'concat::fragment ensure parameter' do
     context 'target file exists' do
       before(:all) do

--- a/spec/system/warn_spec.rb
+++ b/spec/system/warn_spec.rb
@@ -1,12 +1,9 @@
 require 'spec_helper_system'
 
-describe 'basic concat test' do
-  context 'should run successfully' do
+describe 'concat warn =>' do
+  context 'true should enable default warning message' do
     pp = <<-EOS
       concat { '/tmp/concat/file':
-        owner => root,
-        group => root,
-        mode  => '0644',
         warn  => true,
       }
 
@@ -34,6 +31,74 @@ describe 'basic concat test' do
     describe file('/tmp/concat/file') do
       it { should be_file }
       it { should contain '# This file is managed by Puppet. DO NOT EDIT.' }
+      it { should contain '1' }
+      it { should contain '2' }
+    end
+  end
+  context 'false should not enable default warning message' do
+    pp = <<-EOS
+      concat { '/tmp/concat/file':
+        warn  => false,
+      }
+
+      concat::fragment { '1':
+        target  => '/tmp/concat/file',
+        content => '1',
+        order   => '01',
+      }
+
+      concat::fragment { '2':
+        target  => '/tmp/concat/file',
+        content => '2',
+        order   => '02',
+      }
+    EOS
+
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
+    end
+
+    describe file('/tmp/concat/file') do
+      it { should be_file }
+      it { should_not contain '# This file is managed by Puppet. DO NOT EDIT.' }
+      it { should contain '1' }
+      it { should contain '2' }
+    end
+  end
+  context '# foo should overide default warning message' do
+    pp = <<-EOS
+      concat { '/tmp/concat/file':
+        warn  => '# foo',
+      }
+
+      concat::fragment { '1':
+        target  => '/tmp/concat/file',
+        content => '1',
+        order   => '01',
+      }
+
+      concat::fragment { '2':
+        target  => '/tmp/concat/file',
+        content => '2',
+        order   => '02',
+      }
+    EOS
+
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
+    end
+
+    describe file('/tmp/concat/file') do
+      it { should be_file }
+      it { should contain '# foo' }
       it { should contain '1' }
       it { should contain '2' }
     end

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -14,7 +14,6 @@ describe 'concat', :type => :define do
       :group          => nil,
       :mode           => '0644',
       :warn           => false,
-      :warn_message   => nil,
       :force          => false,
       :backup         => 'puppet',
       :replace        => true,
@@ -86,9 +85,25 @@ describe 'concat', :type => :define do
             "-d #{concatdir}/#{safe_name}"
 
       # flag order: fragdir, warnflag, forceflag, orderflag, newlineflag 
-      if p[:warn]
-        message = p[:warn_message] || default_warn_message
-        cmd += " -w \'#{message}\'"
+      if p.has_key?(:warn)
+        case p[:warn]
+        when TrueClass
+          message = default_warn_message
+        when 'true', 'yes', 'on'
+          # should generate a stringified boolean warning
+          message = default_warn_message
+        when FalseClass
+          message = nil
+        when 'false', 'no', 'off'
+          # should generate a stringified boolean warning
+          message = nil
+        else
+          message = p[:warn]
+        end
+
+        unless message.nil?
+          cmd += " -w \'#{message}\'"
+        end
       end
 
       cmd += " -f" if p[:force]
@@ -243,9 +258,21 @@ describe 'concat', :type => :define do
   end # mode =>
 
   context 'warn =>' do
-    [true, false].each do |warn|
+    [true, false, '# foo'].each do |warn|
       context warn do
         it_behaves_like 'concat', '/etc/foo.bar', { :warn => warn }
+      end
+    end
+
+    context '(stringified boolean)' do
+      ['true', 'yes', 'on', 'false', 'no', 'off'].each do |warn|
+        context warn do
+          it_behaves_like 'concat', '/etc/foo.bar', { :warn => warn }
+
+          it 'should create a warning' do
+            pending('rspec-puppet support for testing warning()')
+          end
+        end
       end
     end
 
@@ -253,41 +280,10 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :warn => 123 }}
       it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /is not a boolean/)
+        expect { should }.to raise_error(Puppet::Error, /is not a string or boolean/)
       end
     end
   end # warn =>
-
-  context 'warn_message =>' do
-    context '# ashp replaced your file' do
-      # should do nothing unless warn == true;
-      # but we can't presently test that because concatfragments.sh isn't run
-      # from rspec-puppet tests
-      context 'warn =>' do
-        context 'true' do
-          it_behaves_like 'concat', '/etc/foo.bar', {
-            :warn         => true,
-            :warn_message => '# ashp replaced your file'
-          }
-        end
-
-        context 'false' do
-          it_behaves_like 'concat', '/etc/foo.bar', {
-            :warn         => false,
-            :warn_message => '# ashp replaced your file'
-          }
-        end
-      end
-    end
-
-    context 'false' do
-      let(:title) { '/etc/foo.bar' }
-      let(:params) {{ :warn_message => false }}
-      it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /is not a string/)
-      end
-    end
-  end # warn_message =>
 
   context 'force =>' do
     [true, false].each do |force|


### PR DESCRIPTION
Partially reverting the $warn/$warn_message param split from eaf8407 as this
change was unnecessarily API breaking.  Instead, we are adding string/bool type
validating to the $warn parameter and deprecation warnings for the usage of
stringified boolean values (eg, 'true', 'on', etc.). In a future major release,
the logic can be simplified to treating all string values as a warning message.
