### PR TITLE
remove workaround for Rubygems 2.2.0 bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ branches:
   only:
     - master
 language: ruby
-# work around RubyGems 2.2.0 breaking ruby 1.8.7
-# https://github.com/rubygems/rubygems/pull/763
-# https://github.com/freerange/mocha/commit/66bab2a8f4e7cd8734bf88e6f32157c0d5153125
-before_install:
-  - gem update --system 2.1.11
-  - gem --version
 bundler_args: --without development
 script: bundle exec rake spec SPEC_OPTS='--format documentation'
 after_success:


### PR DESCRIPTION
https://github.com/rubygems/rubygems/pull/763 is merged and released in Rubygems 2.2.1. A forced downgrade is no longer required.

Commit: https://github.com/rubygems/rubygems/commit/335ea9d79989fced8f02225115c89d7a8534fa49
