### PR TITLE
Fix fragdir creation problem:

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,6 +141,8 @@ define concat(
   if $ensure == 'present' {
     file { $fragdir:
       ensure => directory,
+      owner  => $::id,
+      group  => $::id,
       mode   => '0750',
     }
 


### PR DESCRIPTION
In https://github.com/puppetlabs/puppetlabs-postgresql/pull/343 it
was discovered that if postgres was the first module to use concat
then the File defaults were being incorrectly applied to the fragdir.

I assume the issue with a hardcoded owner/group was to do with Windows,
and not incorrectly trying to use root.  $::id will at least set it to
be owned by the user running Puppet, for safety.

Other alternatives include making local $_id and $_gid facts and using
those within concat.
