### PR TITLE
Switch test to use a much higher gid/uid

### DIFF
--- a/spec/acceptance/concat_spec.rb
+++ b/spec/acceptance/concat_spec.rb
@@ -57,8 +57,8 @@ describe 'basic concat test' do
 
   context 'owner/group non-root' do
     before(:all) do
-      shell "groupadd -g 42 bob"
-      shell "useradd -u 42 -g 42 bob"
+      shell "groupadd -g 64444 bob"
+      shell "useradd -u 42 -g 64444 bob"
     end
     after(:all) do
       shell "userdel bob"


### PR DESCRIPTION
This fixes the gid collisions on debian/ubuntu tests.
