### PR TITLE
be more ignorant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 spec/fixtures
 .rspec_system
 .bundle
+*.sw*


### PR DESCRIPTION
ignore vim swp files. May be especially important when those sneak into
released packages, such as in the case of 1.0.1:

```
    concat/manifests/.setup.pp.swp
    concat/manifests/.init.pp.swp
    concat/manifests/.fragment.pp.swp
    concat/files/.concatfragments.sh.swp
    concat/spec/acceptance/.warn_spec.rb.swp
    concat/spec/acceptance/.symbolic_name_spec.rb.swp
    concat/spec/acceptance/.order_spec.rb.swp
    concat/spec/acceptance/.fragment_source_spec.rb.swp
    concat/spec/acceptance/.deprecation_warnings_spec.rb.swp
    concat/spec/acceptance/.empty_spec.rb.swp
    concat/spec/acceptance/.concat_spec.rb.swo
    concat/spec/acceptance/.replace_spec.rb.swp
    concat/spec/acceptance/.basic_spec.rb.swp
    concat/spec/acceptance/.deprecation_warnings_spec.rb.swo
    concat/spec/acceptance/.concat_spec.rb.swp
    concat/spec/acceptance/.backup_spec.rb.swp
```
