### PR TITLE
fix quoting, fix numeric sorting

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -121,7 +121,7 @@ fi
 IFS_BACKUP=$IFS
 IFS='
 '
-for fragfile in `find fragments/ -type f -follow | xargs -n1 basename | LC_ALL=C sort ${SORTARG}`
+for fragfile in `find fragments/ -type f -follow -print0 | xargs -0 -n1 basename | LC_ALL=C sort ${SORTARG}`
 do
     cat fragments/$fragfile >> "fragments.concat"
 done


### PR DESCRIPTION
fix quoting resulting in failed test even when fragments directory is not empty
fix numeric sorting, the output of find makes sort do alphanumeric sorting even if -n is provided, so calling basename with xargs is needed
