### PR TITLE
fix numeric sorting

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -117,9 +117,9 @@ fi
 IFS_BACKUP=$IFS
 IFS='
 '
-for fragfile in `find fragments/ -type f -follow | LC_ALL=C sort ${SORTARG}`
+for fragfile in `find fragments/ -type f -follow -print0 | xargs -0 -n1 basename | LC_ALL=C sort ${SORTARG}`
 do
-    cat $fragfile >> "fragments.concat"
+    cat "fragments/$fragfile" >> "fragments.concat"
     # Handle newlines.
     if [ "x${ENSURE_NEWLINE}" != "x" ]; then
       echo >> "fragments.concat"


### PR DESCRIPTION
Reworked change to be in a separate branch as requested. This is a fix for numeric sorting supporting spaces in the fragment file names. 
