### PR TITLE
Change default 'order' parameter to be a string

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -28,7 +28,7 @@ define concat::fragment(
     $target,
     $content = undef,
     $source  = undef,
-    $order   = 10,
+    $order   = '10',
     $ensure  = undef,
     $mode    = undef,
     $owner   = undef,


### PR DESCRIPTION
Under Puppet 3.5.1 (and possibly earlier versions, too), the validate_string($order)
fails when $order is actaully a numeric type.  Apparently there is more strict type
checking now.  Can't just change validate_string to a is_numeric check, because it's
fairly common to use strings like '01' for the order parameter, which doesn't pass
the is_numeric test.  Additionally, there is nothing saying that $order must be a
number.  Ultimately the ordering gets implemented as filesystem directory list
sorting.
