### PR TITLE
enable the ruby concat script on Solaris

### DIFF
--- a/files/concatfragments.rb
+++ b/files/concatfragments.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # Script to concat files to a config file.
 #
 # Given a directory like this:

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -7,7 +7,7 @@
 #   Since puppet should always manage files in $concatdir and they should
 #   not be deleted ever, /tmp is not an option.
 #
-# It also copies out the concatfragments.sh file to ${concatdir}/bin
+# It also copies out the concatfragments.{sh,rb} file to ${concatdir}/bin
 #
 class concat::setup {
   if $caller_module_name != $module_name {
@@ -19,23 +19,29 @@ class concat::setup {
   } else {
     fail ('$concat_basedir not defined. Try running again with pluginsync=true on the [master] and/or [main] section of your node\'s \'/etc/puppet/puppet.conf\'.')
   }
-  
-  # owner and mode of fragment files (on windows owner and access rights should be inherited from concatdir and not explicitly set to avoid problems)
-  $fragment_owner = $osfamily ? { 'windows' => undef, default => $::id }
-  $fragment_mode  = $osfamily ? { 'windows' => undef, default => '0640' }
 
-  $script_name = $::kernel ? {
-    'windows' => 'concatfragments.rb',
-    default   => 'concatfragments.sh'
+  # owner and mode of fragment files (on windows owner and access rights should
+  # be inherited from concatdir and not explicitly set to avoid problems)
+  $fragment_owner = $::osfamily ? { 'windows' => undef, default => $::id }
+  $fragment_mode  = $::osfamily ? { 'windows' => undef, default => '0640' }
+
+  # PR #174 introduced changes to the concatfragments.sh script that are
+  # incompatible with Solaris 10 but reportedly OK on Solaris 11.  As a work
+  # around we are enable the .rb concat script on all Solaris versions.  If
+  # this goes smoothly, we should move towards completely eliminating the .sh
+  # version.
+  $script_name = $::osfamily? {
+    /(Windows|Solaris)/ => 'concatfragments.rb',
+    default             => 'concatfragments.sh'
   }
 
   $script_path = "${concatdir}/bin/${script_name}"
 
-  $script_owner = $osfamily ? { 'windows' => undef, default => $::id }
+  $script_owner = $::osfamily ? { 'windows' => undef, default => $::id }
 
-  $script_mode = $osfamily ? { 'windows' => undef, default => '0755' }
+  $script_mode = $::osfamily ? { 'windows' => undef, default => '0755' }
 
-  $script_command   = $::kernel ? {
+  $script_command = $::osfamily? {
     'windows' => "ruby.exe ${script_path}",
     default   => $script_path
   }

--- a/spec/unit/classes/concat_setup_spec.rb
+++ b/spec/unit/classes/concat_setup_spec.rb
@@ -39,4 +39,46 @@ describe 'concat::setup', :type => :class do
       pending('rspec-puppet support for testing warning()')
     end
   end
+
+  context "on osfamily Solaris" do
+    concatdir = '/foo'
+    let(:facts) do
+      {
+        :concat_basedir => concatdir,
+        :osfamily       => 'Solaris',
+        :id             => 'root',
+      }
+    end
+
+    it do
+      should contain_file("#{concatdir}/bin/concatfragments.rb").with({
+        :ensure => 'file',
+        :owner  => 'root',
+        :mode   => '0755',
+        :source => 'puppet:///modules/concat/concatfragments.rb',
+        :backup => false,
+      })
+    end
+  end # on osfamily Solaris
+
+  context "on osfamily Windows" do
+    concatdir = '/foo'
+    let(:facts) do
+      {
+        :concat_basedir => concatdir,
+        :osfamily       => 'Windows',
+        :id             => 'batman',
+      }
+    end
+
+    it do
+      should contain_file("#{concatdir}/bin/concatfragments.rb").with({
+        :ensure => 'file',
+        :owner  => nil,
+        :mode   => nil,
+        :source => 'puppet:///modules/concat/concatfragments.rb',
+        :backup => false,
+      })
+    end
+  end # on osfamily Windows
 end


### PR DESCRIPTION
Per discussion on #174, Solaris 10 does not support the find/xargs
switches that were introduced in that PR (but Solaris 11 does).
