### PR TITLE
Add support for concat on FreeBSD

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -70,8 +70,9 @@ define concat::fragment(
   $safe_target_name = regsubst($target, '[/:\n]', '_', 'GM')
   $concatdir        = $concat::setup::concatdir
   $fragdir          = "${concatdir}/${safe_target_name}"
-  $fragowner            = $concat::setup::fragment_owner
-  $fragmode             = $concat::setup::fragment_mode
+  $fragowner        = $concat::setup::fragment_owner
+  $fraggroup        = $concat::setup::fragment_group
+  $fragmode         = $concat::setup::fragment_mode
 
   # The file type's semantics are problematic in that ensure => present will
   # not over write a pre-existing symlink.  We are attempting to provide
@@ -113,6 +114,7 @@ define concat::fragment(
   file { "${fragdir}/fragments/${order}_${safe_name}":
     ensure  => $safe_ensure,
     owner   => $fragowner,
+    group   => $fraggroup,
     mode    => $fragmode,
     source  => $source,
     content => $content,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -23,6 +23,11 @@ class concat::setup {
   # owner and mode of fragment files (on windows owner and access rights should
   # be inherited from concatdir and not explicitly set to avoid problems)
   $fragment_owner = $::osfamily ? { 'windows' => undef, default => $::id }
+  $fragment_group = $::osfamily ? {
+    'windows' => undef,
+    'FreeBSD' => 'wheel',
+    default   => $::id
+  }
   $fragment_mode  = $::osfamily ? { 'windows' => undef, default => '0640' }
 
   # PR #174 introduced changes to the concatfragments.sh script that are
@@ -38,6 +43,11 @@ class concat::setup {
   $script_path = "${concatdir}/bin/${script_name}"
 
   $script_owner = $::osfamily ? { 'windows' => undef, default => $::id }
+  $script_group = $::osfamily ? {
+    'windows' => undef,
+    'FreeBSD' => 'wheel',
+    default   => $::id
+  }
 
   $script_mode = $::osfamily ? { 'windows' => undef, default => '0755' }
 
@@ -53,12 +63,15 @@ class concat::setup {
   file { $script_path:
     ensure => file,
     owner  => $script_owner,
+    group  => $script_group,
     mode   => $script_mode,
     source => "puppet:///modules/concat/${script_name}",
   }
 
   file { [ $concatdir, "${concatdir}/bin" ]:
     ensure => directory,
+    owner  => $script_owner,
+    group  => $script_group,
     mode   => '0755',
   }
 }

--- a/spec/unit/classes/concat_setup_spec.rb
+++ b/spec/unit/classes/concat_setup_spec.rb
@@ -81,4 +81,27 @@ describe 'concat::setup', :type => :class do
       })
     end
   end # on osfamily Windows
+
+  context "on osfamily FreeBSD" do
+    concatdir = '/foo'
+    let(:facts) do
+      {
+        :concat_basedir => concatdir,
+        :osfamily       => 'FreeBSD',
+        :id             => 'root',
+      }
+    end
+
+    it do
+      should contain_file("#{concatdir}/bin/concatfragments.sh").with({
+        :ensure => 'file',
+        :owner  => 'root',
+        :group  => 'wheel',
+        :mode   => '0755',
+        :source => 'puppet:///modules/concat/concatfragments.sh',
+        :backup => false,
+      })
+    end
+  end # on osfamily FreeBSD
+
 end


### PR DESCRIPTION
FreeBSD doesn't have a root group - it has a wheel group. This allows us to support that properly in FreeBSD. I've added tests for this as well. It's probably worth noting that the tests/rspec etc. is quite out of date and throwing deprecation warnings - but they pass still.
