### PR TITLE
Add quotes to the ruby script location

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -42,7 +42,7 @@ class concat::setup {
   $script_mode = $::osfamily ? { 'windows' => undef, default => '0755' }
 
   $script_command = $::osfamily? {
-    'windows' => "ruby.exe ${script_path}",
+    'windows' => "ruby.exe '${script_path}'",
     default   => $script_path
   }
 


### PR DESCRIPTION
Without this patch, if the ruby script is located in a path with spaces, it will not work.

It could happen in cases like `Windows Server 2003 R2` (minimum version supported officially by Puppet), where the base puppet is in `C:/Documents and Settings/All Users/Application Data/PuppetLabs`.
