### PR TITLE
README.md : add missing ','

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ concat { '/tmp/file':
 }
 
 concat::fragment { 'tmpfile':
-  target  => '/tmp/file'
+  target  => '/tmp/file',
   content => 'test contents',
   order   => '01'
 }


### PR DESCRIPTION
Small typo, a ',' was missing on the minimal exampel conf
