### PR TITLE
added missing line endings (-l) support for windows and solaris

### DIFF
--- a/files/concatfragments.rb
+++ b/files/concatfragments.rb
@@ -45,7 +45,8 @@ settings = {
   :test    => false,
   :force   => false,
   :warn    => "",
-  :sortarg => ""
+  :sortarg => "",
+  :newline => false
 }
 
 OptionParser.new do |opts|
@@ -76,6 +77,10 @@ OptionParser.new do |opts|
 
   opts.on("-n", "--sort", "Sort the output numerically rather than the default alpha sort") do
     settings[:sortarg] = "-n"
+  end
+
+  opts.on("-l", "--line", "Append a newline") do
+    settings[:newline] = true
   end
 end.parse!
 
@@ -119,8 +124,15 @@ end
 # find all the files in the fragments directory, sort them numerically and concat to fragments.concat in the working dir
 open('fragments.concat', 'a') do |f|
   Dir.entries("fragments").sort.each{ |entry|
+
     if File.file?(File.join("fragments", entry))
-	  f << File.read(File.join("fragments", entry))
+      f << File.read(File.join("fragments", entry))
+
+      # append a newline if we were asked to (invoked with -l)
+      if settings[:newline]
+        f << "\n"
+      end
+
     end
   }
 end


### PR DESCRIPTION
Adds newline support for Windows and Solaris (users of the concatfragments.rb script)

Addresses MODULES-1205

Don't believe there are any tests I need to satisfy here(?)
