### PR TITLE
Filename too long error

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -66,7 +66,7 @@ define concat::fragment(
 
   include concat::setup
 
-  $safe_name        = regsubst($name, '[/:\n]', '_', 'GM')
+  $safe_name        = md5($name)
   $safe_target_name = regsubst($target, '[/:\n]', '_', 'GM')
   $concatdir        = $concat::setup::concatdir
   $fragdir          = "${concatdir}/${safe_target_name}"


### PR DESCRIPTION
Hi,

in some cases the filename the concat module want to write to the tmp directory is too long. This patch uses the md5() function to generate a safe name.

HTH,

Jan
