### PR TITLE
fix: permitting $backup to be boolean false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,9 @@ define concat(
     fail('$warn is not a string or boolean')
   }
   validate_bool($force)
-  validate_string($backup)
+  if ! is_bool($backup) and ! is_string($backup) {
+    fail('$backup must be string or bool!')
+  }
   validate_bool($replace)
   validate_re($order, '^alpha$|^numeric$')
   validate_bool($ensure_newline)

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -307,10 +307,18 @@ describe 'concat', :type => :define do
     end
 
     context 'false' do
+      it_behaves_like 'concat', '/etc/foo.bar', { :backup => false }
+    end
+
+    context 'true' do
+      it_behaves_like 'concat', '/etc/foo.bar', { :backup => true }
+    end
+
+    context 'true' do
       let(:title) { '/etc/foo.bar' }
-      let(:params) {{ :backup => false }}
+      let(:params) {{ :backup => [] }}
       it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /is not a string/)
+        expect { should }.to raise_error(Puppet::Error, /backup must be string or bool/)
       end
     end
   end # backup =>


### PR DESCRIPTION
concat::backup can actually be a boolean false, which currently is not permitted by the validation, and should be. now it is :)
