### PR TITLE
Lack of idempotency with `ensure => 'absent'`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -223,10 +223,12 @@ define concat(
       default   => '/bin:/usr/bin',
     }
 
+    # Need to have an unless here for idempotency.
     exec { "concat_${name}":
       alias   => "concat_${fragdir}",
       command => $absent_exec_command,
-      path    => $absent_exec_path
+      unless  => $absent_exec_command,
+      path    => $absent_exec_path,
     }
   }
 }

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -144,6 +144,7 @@ describe 'concat', :type => :define do
         should contain_exec("concat_#{title}").with({
           :alias   => "concat_#{fragdir}",
           :command => 'true',
+          :unless  => 'true',
           :path    => '/bin:/usr/bin',
         })
       end


### PR DESCRIPTION
Need to add an unless to the exec in the case we have `ensure =>
'absent'` for the concat, otherwise the exec (of true) runs every time.
