### PR TITLE
Reset poisoned defaults from Exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,6 +140,12 @@ define concat(
     backup  => false,
   }
 
+  # reset poisoned Exec defaults
+  Exec {
+    user  => undef,
+    group => undef,
+  }
+
   if $ensure == 'present' {
     file { $fragdir:
       ensure => directory,


### PR DESCRIPTION
Concat module currently picks up unintended defaults for Exec{}.

Specifically, this affects the user and group used when creating files and this can lead to permission denied errors that are really difficult for users to remedy.

This PR 'fixes' this by unsetting 'poisioned' Exec{} defaults in the ::concat scope
- I'm working on a bug report (private jira) to illustrate this
