### PR TITLE
Support running a validation command on the destination file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ Ensure there's a newline at the end of the fragments.
 - ensure_newline => true
 - ensure_newline => false
 
+#####`validate_cmd`
+Ensure the destination file passes the following validation command.
+
+######Example
+- validate_cmd => '/usr/sbin/apache2 -t -f %'
+- validate_cmd => '/usr/sbin/visudo -c -f %'
+
 ####concat::fragment
 
 #####`target`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,7 @@ define concat(
   $replace        = true,
   $order          = 'alpha',
   $ensure_newline = false,
+  $validate_cmd   = undef,
   $gnu            = undef
 ) {
   validate_re($ensure, '^present$|^absent$')
@@ -173,15 +174,16 @@ define concat(
     }
 
     file { $name:
-      ensure  => present,
-      owner   => $owner,
-      group   => $group,
-      mode    => $mode,
-      replace => $replace,
-      path    => $path,
-      alias   => "concat_${name}",
-      source  => "${fragdir}/${concat_name}",
-      backup  => $backup,
+      ensure       => present,
+      owner        => $owner,
+      group        => $group,
+      mode         => $mode,
+      replace      => $replace,
+      path         => $path,
+      alias        => "concat_${name}",
+      source       => "${fragdir}/${concat_name}",
+      validate_cmd => $validate_cmd,
+      backup       => $backup,
     }
 
     # remove extra whitespace from string interpolation to make testing easier

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,9 @@ define concat(
   validate_bool($replace)
   validate_re($order, '^alpha$|^numeric$')
   validate_bool($ensure_newline)
+  if $validate_cmd and ! is_string($validate_cmd) {
+    fail('$validate_cmd must be a string')
+  }
   if $gnu {
     warning('The $gnu parameter to concat is deprecated and has no effect')
   }

--- a/spec/acceptance/validation_spec.rb
+++ b/spec/acceptance/validation_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_acceptance'
+
+describe 'concat validate_cmd parameter' do
+  basedir = default.tmpdir('concat')
+  context '=> "/usr/bin/test -e %"' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory
+        }
+      EOS
+
+      apply_manifest(pp)
+    end
+    pp = <<-EOS
+      concat { '#{basedir}/file':
+        validate_cmd => '/usr/bin/test -e %',
+      }
+      concat::fragment { 'content':
+        target  => '#{basedir}/file',
+        content => 'content',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/file") do
+      it { should be_file }
+      it { should contain 'content' }
+    end
+  end
+end

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -19,6 +19,7 @@ describe 'concat', :type => :define do
       :replace        => true,
       :order          => 'alpha',
       :ensure_newline => false,
+      :validate_cmd   => nil,
     }.merge(params)
 
     safe_name            = title.gsub('/', '_')
@@ -76,15 +77,16 @@ describe 'concat', :type => :define do
 
       it do
         should contain_file(title).with(file_defaults.merge({
-          :ensure  => 'present',
-          :owner   => p[:owner],
-          :group   => p[:group],
-          :mode    => p[:mode],
-          :replace => p[:replace],
-          :path    => p[:path],
-          :alias   => "concat_#{title}",
-          :source  => "#{fragdir}/#{concat_name}",
-          :backup  => p[:backup],
+          :ensure       => 'present',
+          :owner        => p[:owner],
+          :group        => p[:group],
+          :mode         => p[:mode],
+          :replace      => p[:replace],
+          :path         => p[:path],
+          :alias        => "concat_#{title}",
+          :source       => "#{fragdir}/#{concat_name}",
+          :validate_cmd => p[:validate_cmd],
+          :backup       => p[:backup],
         }))
       end
 
@@ -379,6 +381,22 @@ describe 'concat', :type => :define do
       end
     end
   end # ensure_newline =>
+
+  context 'validate_cmd =>' do
+    context '/usr/bin/test -e %' do
+      it_behaves_like 'concat', '/etc/foo.bar', { :validate_cmd => '/usr/bin/test -e %' }
+    end
+
+    [ 1234, true ].each do |cmd|
+      context cmd do
+        let(:title) { '/etc/foo.bar' }
+        let(:params) {{ :validate_cmd => cmd }}
+        it 'should fail' do
+          expect { should }.to raise_error(Puppet::Error, /\$validate_cmd must be a string/)
+        end
+      end
+    end
+  end # validate_cmd =>
 
   describe 'deprecated parameter' do
     context 'gnu =>' do


### PR DESCRIPTION
This patch allows a user to pass an optional `validate_cmd` parameter to a `concat` resource, which in turn will run a command to validate the output of the file before the module replaces it. It follows the same semantics as the `validate_cmd` parameter to the `file` resource.

Example:
```puppet
concat { '/etc/httpd/conf/httpd.conf':
  ensure       => file,
  validate_cmd => '/usr/sbin/apache2 -t -f %',
  owner        => 'apache2',
  group        => 'apache2',
  mode         => '0644'
}
```