### PR TITLE
use concatfragments.rb on AIX

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -31,8 +31,8 @@ class concat::setup {
   # this goes smoothly, we should move towards completely eliminating the .sh
   # version.
   $script_name = $::osfamily? {
-    /(?i:(Windows|Solaris))/ => 'concatfragments.rb',
-    default                  => 'concatfragments.sh'
+    /(?i:(Windows|Solaris|AIX))/ => 'concatfragments.rb',
+    default                      => 'concatfragments.sh'
   }
 
   $script_path = "${concatdir}/bin/${script_name}"


### PR DESCRIPTION
AIX find does not support the print0 option. It's basically the same as on Solaris:

Debug: Executing '/var/lib/puppet/concat/bin/concatfragments.sh -o "/var/lib/puppet/concat/_var_ossec_etc_ossec-agent.conf/fragments.concat.out" -d "/var/lib/puppet/concat/_var_ossec_etc_ossec-agent.conf" -t'
Debug: /Stage[main]/Ossec::Client/Concat[/var/ossec/etc/ossec-agent.conf]/Exec[concat_/var/ossec/etc/ossec-agent.conf]/unless: find: bad option -print0