### PR TITLE
Define travis matrix in .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,1 +1,9 @@
 ---
+.travis.yml:
+  includes:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0"


### PR DESCRIPTION
Since the other modules need to wait for a major release before
deprecating Puppet 2.7 support, this module's travis.yml is out of sync
and will need to stay that way for a while.
