### PR TITLE
Don't manage Gemfile with modulesync

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,3 +7,5 @@
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0"
+Gemfile:
+  unmanaged: true


### PR DESCRIPTION
7d49b5f made changes to the Gemfile that can't be modeled in the
modulesync templates. This commit changes the Gemfile to be unmanaged
for the time being.