### PR TITLE
MODULES-1456 - make sure ruby is in path on PE

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -187,6 +187,17 @@ define concat(
     # remove extra whitespace from string interpolation to make testing easier
     $command = strip(regsubst("${script_command} -o \"${fragdir}/${concat_name}\" -d \"${fragdir}\" ${warnflag} ${forceflag} ${orderflag} ${newlineflag}", '\s+', ' ', 'G'))
 
+    # make sure ruby is in the path for PE
+    if $::is_pe {
+      if $::kernel == 'windows' {
+        $command_path = "${::env_windows_installdir}/bin:${::path}"
+      } else {
+        $command_path = "/opt/puppet/bin:${::path}"
+      }
+    } else {
+      $command_path = $::path
+    }
+
     # if puppet is running as root, this exec should also run as root to allow
     # the concatfragments.sh script to potentially be installed in path that
     # may not be accessible by a target non-root owner.
@@ -196,7 +207,7 @@ define concat(
       notify    => File[$name],
       subscribe => File[$fragdir],
       unless    => "${command} -t",
-      path      => $::path,
+      path      => $command_path,
       require   => [
         File[$fragdir],
         File["${fragdir}/fragments"],

--- a/spec/unit/classes/concat_setup_spec.rb
+++ b/spec/unit/classes/concat_setup_spec.rb
@@ -11,6 +11,7 @@ describe 'concat::setup', :type => :class do
         :caller_module_name => 'Test',
         :osfamily           => 'Debian',
         :id                 => 'root',
+        :is_pe              => false,
       }
     end
 
@@ -55,6 +56,7 @@ describe 'concat::setup', :type => :class do
         :caller_module_name => 'Test',
         :osfamily           => 'Solaris',
         :id                 => 'root',
+        :is_pe              => false,
       }
     end
 
@@ -77,6 +79,7 @@ describe 'concat::setup', :type => :class do
         :caller_module_name => 'Test',
         :osfamily           => 'windows',
         :id                 => 'batman',
+        :is_pe              => false,
       }
     end
 

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -30,6 +30,7 @@ describe 'concat::fragment', :type => :define do
         :id             => id,
         :osfamily       => 'Debian',
         :path           => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe          => false,
       }
     end
     let(:params) { params }
@@ -71,7 +72,7 @@ describe 'concat::fragment', :type => :define do
 
     context 'false' do
       let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp' }}
+      let(:facts) {{ :concat_basedir => '/tmp', :is_pe => false }}
       let(:params) {{ :target => false }}
 
       it 'should fail' do
@@ -92,7 +93,7 @@ describe 'concat::fragment', :type => :define do
 
     context 'any value other than \'present\' or \'absent\'' do
       let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp' }}
+      let(:facts) {{ :concat_basedir => '/tmp', :is_pe => false }}
       let(:params) {{ :ensure => 'invalid', :target => '/etc/motd' }}
 
       it 'should create a warning' do
@@ -113,7 +114,7 @@ describe 'concat::fragment', :type => :define do
 
     context 'false' do
       let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp' }}
+      let(:facts) {{ :concat_basedir => '/tmp', :is_pe => false }}
       let(:params) {{ :content => false, :target => '/etc/motd' }}
 
       it 'should fail' do
@@ -134,7 +135,7 @@ describe 'concat::fragment', :type => :define do
 
     context 'false' do
       let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp' }}
+      let(:facts) {{ :concat_basedir => '/tmp', :is_pe => false }}
       let(:params) {{ :source => false, :target => '/etc/motd' }}
 
       it 'should fail' do
@@ -155,7 +156,7 @@ describe 'concat::fragment', :type => :define do
 
     context 'false' do
       let(:title) { 'motd_header' }
-      let(:facts) {{ :concat_basedir => '/tmp' }}
+      let(:facts) {{ :concat_basedir => '/tmp', :is_pe => false }}
       let(:params) {{ :order => false, :target => '/etc/motd' }}
 
       it 'should fail' do
@@ -174,6 +175,7 @@ describe 'concat::fragment', :type => :define do
           :concat_basedir => '/tmp',
           :osfamily       => 'Debian',
           :id             => 'root',
+          :is_pe          => false,
         }
       end
       let(:params) do
@@ -196,6 +198,7 @@ describe 'concat::fragment', :type => :define do
           :concat_basedir => '/tmp',
           :osfamily       => 'Debian',
           :id             => 'root',
+          :is_pe          => false,
         }
       end
       let(:params) do
@@ -218,6 +221,7 @@ describe 'concat::fragment', :type => :define do
           :concat_basedir => '/tmp',
           :osfamily       => 'Debian',
           :id             => 'root',
+          :is_pe          => false,
         }
       end
       let(:params) do

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -40,6 +40,7 @@ describe 'concat', :type => :define do
         :osfamily       => 'Debian',
         :path           => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         :kernel         => 'Linux',
+        :is_pe          => false,
       }
     end
 


### PR DESCRIPTION
Ruby is not in the path for all PE installations, so make sure the
concat script is run with ruby in the path.