### PR TITLE
Fix validate_cmd file resource parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Ensure there's a newline at the end of the fragments.
 
 #####`validate_cmd`
 Ensure the destination file passes the following validation command.
+Only supported on Puppet >= 3.5.0.
 
 ######Example
 - validate_cmd => '/usr/sbin/apache2 -t -f %'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -185,8 +185,14 @@ define concat(
       path         => $path,
       alias        => "concat_${name}",
       source       => "${fragdir}/${concat_name}",
-      validate_cmd => $validate_cmd,
       backup       => $backup,
+    }
+
+    # Only newer versions of puppet 3.x support the validate_cmd parameter
+    if $validate_cmd {
+      File[$name] {
+        validate_cmd => $validate_cmd,
+      }
     }
 
     # remove extra whitespace from string interpolation to make testing easier


### PR DESCRIPTION
The validate_cmd parameter is only valid on newer versions of puppet.
This module is supporting all 3.x versions of puppet. This commit only
applies the validate_cmd parameter to the file resource if it is
defined and adds documentation noting that it will not work on older
versons of puppet.