### PR TITLE
Fix validate_cmd usage in older Puppet

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,7 +196,7 @@ define concat(
         }
       }
       else {
-        validate_cmd("${fragdir}/${concat_name}", $validate_cmd)
+        fail("validate_cmd is a limted to Puppet > 3.5, you are on ${::puppetversion}")
       }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -188,10 +188,15 @@ define concat(
       backup       => $backup,
     }
 
-    # Only newer versions of puppet 3.x support the validate_cmd parameter
+    # Only Puppet > 3.5 supports the validate_cmd parameter
     if $validate_cmd {
-      File[$name] {
-        validate_cmd => $validate_cmd,
+      if versioncmp($::puppetversion, '3.5') >= 0 {
+        File[$name] {
+          validate_cmd => $validate_cmd,
+        }
+      }
+      else {
+        validate_cmd("${fragdir}/${concat_name}", $validate_cmd)
       }
     }
 

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -386,8 +386,12 @@ describe 'concat', :type => :define do
   end # ensure_newline =>
 
   context 'validate_cmd =>' do
-    context '/usr/bin/test -e %' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :validate_cmd => '/usr/bin/test -e %' }
+    before(:each) do
+      Puppet::Util::Execution.stubs(:execute)
+    end
+
+    context '/usr/bin/test -e' do
+      it_behaves_like 'concat', '/etc/foo.bar', { :validate_cmd => '/usr/bin/test % -e' }
     end
 
     [ 1234, true ].each do |cmd|

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -86,16 +86,18 @@ describe 'concat', :type => :define do
           :path         => p[:path],
           :alias        => "concat_#{title}",
           :source       => "#{fragdir}/#{concat_name}",
-          :validate_cmd => p[:validate_cmd],
           :backup       => p[:backup],
         }))
+        if (Puppet.version >= '3.5.0')
+          contain_file(title).with(:validate_cmd => p[:validate_cmd])
+        end
       end
 
       cmd = "#{concatdir}/bin/concatfragments.sh " +
             "-o \"#{concatdir}/#{safe_name}/fragments.concat.out\" " +
             "-d \"#{concatdir}/#{safe_name}\""
 
-      # flag order: fragdir, warnflag, forceflag, orderflag, newlineflag 
+      # flag order: fragdir, warnflag, forceflag, orderflag, newlineflag
       if p.has_key?(:warn)
         case p[:warn]
         when TrueClass


### PR DESCRIPTION
Puppet < 3.5 doesn't have validate_cmd on the file parameter. This allows us to add it 
to older puppet without having to restrict versions