### PR TITLE
Check if $is_pe exists before using it

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,7 +199,7 @@ define concat(
     $command = strip(regsubst("${script_command} -o \"${fragdir}/${concat_name}\" -d \"${fragdir}\" ${warnflag} ${forceflag} ${orderflag} ${newlineflag}", '\s+', ' ', 'G'))
 
     # make sure ruby is in the path for PE
-    if $::is_pe {
+    if defined('$is_pe') and $::is_pe {
       if $::kernel == 'windows' {
         $command_path = "${::env_windows_installdir}/bin:${::path}"
       } else {


### PR DESCRIPTION
$is_pe is not a standard fact, so the
current code fails with strict_variables on.