### PR TITLE
Update fragment.pp

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -68,6 +68,7 @@ define concat::fragment(
 
   $safe_name        = regsubst($name, '[/:\n]', '_', 'GM')
   $safe_target_name = regsubst($target, '[/:\n]', '_', 'GM')
+  $safe_order       = regsubst($order, '[/:\n]', '_', 'GM')
   $concatdir        = $concat::setup::concatdir
   $fragdir          = "${concatdir}/${safe_target_name}"
   $fragowner            = $concat::setup::fragment_owner
@@ -110,7 +111,7 @@ define concat::fragment(
 
   # punt on group ownership until some point in the distant future when $::gid
   # can be relied on to be present
-  file { "${fragdir}/fragments/${order}_${safe_name}":
+  file { "${fragdir}/fragments/${safe_order}_${safe_name}":
     ensure  => $safe_ensure,
     owner   => $fragowner,
     mode    => $fragmode,


### PR DESCRIPTION
The fragment code creates a bunch of intermediate files and this patch ensures that they are safely created regardless of the 'order' parameter given. Context: I am creating a grid certificate mapping file whose unique keys, on which the file should be sorted, are certificate subjects like this:

"/DC=org/DC=cilogon/C=US/O=LIGO/CN=Thomas Downes thomas.downes@ligo.org"

This code ensures that the files created are safe using this ordering scheme.