### PR TITLE
Lookup is_pe fact with getvar

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,7 +199,7 @@ define concat(
     $command = strip(regsubst("${script_command} -o \"${fragdir}/${concat_name}\" -d \"${fragdir}\" ${warnflag} ${forceflag} ${orderflag} ${newlineflag}", '\s+', ' ', 'G'))
 
     # make sure ruby is in the path for PE
-    if $::is_pe {
+    if getvar('::is_pe') {
       if $::kernel == 'windows' {
         $command_path = "${::env_windows_installdir}/bin:${::path}"
       } else {


### PR DESCRIPTION
If the system is not running PE, the $::is_pe fact will be undefined,
causing errors when run under strict variables mode. This patch uses
the getvar() function to look up the fact so that it won't fail if not
defined.

Alternative to https://github.com/puppetlabs/puppetlabs-concat/pull/270

This should fix the broken CI for the postgresql module.