### PR TITLE
Revert "Lookup is_pe fact with getvar"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,7 +199,7 @@ define concat(
     $command = strip(regsubst("${script_command} -o \"${fragdir}/${concat_name}\" -d \"${fragdir}\" ${warnflag} ${forceflag} ${orderflag} ${newlineflag}", '\s+', ' ', 'G'))
 
     # make sure ruby is in the path for PE
-    if getvar('::is_pe') {
+    if $::is_pe {
       if $::kernel == 'windows' {
         $command_path = "${::env_windows_installdir}/bin:${::path}"
       } else {


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-concat#273

Using defined() as in #270 is preferred in order to be compatible with the future parser.