### PR TITLE
Add validation for order parameter

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -42,6 +42,8 @@ define concat::fragment(
   }
   if !(is_string($order) or is_integer($order)) {
     fail('$order is not a string or integer.')
+  } elsif $order =~ /[:\n\/]/ {
+    fail("Order cannot contain '/', ':', or '\n'.")
   }
   if $mode {
     warning('The $mode parameter to concat::fragment is deprecated and has no effect')

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -163,6 +163,34 @@ describe 'concat::fragment', :type => :define do
         expect { should }.to raise_error(Puppet::Error, /is not a string or integer/)
       end
     end
+
+    context '123:456' do
+      let(:title) { 'motd_header' }
+      let(:facts) {{ :concat_basedir => '/tmp', :is_pe => false }}
+      let(:params) {{ :order => '123:456', :target => '/etc/motd' }}
+
+      it 'should fail' do
+        expect { should }.to raise_error(Puppet::Error, /cannot contain/)
+      end
+    end
+    context '123/456' do
+      let(:title) { 'motd_header' }
+      let(:facts) {{ :concat_basedir => '/tmp', :is_pe => false }}
+      let(:params) {{ :order => '123/456', :target => '/etc/motd' }}
+
+      it 'should fail' do
+        expect { should }.to raise_error(Puppet::Error, /cannot contain/)
+      end
+    end
+    context '123\n456' do
+      let(:title) { 'motd_header' }
+      let(:facts) {{ :concat_basedir => '/tmp', :is_pe => false }}
+      let(:params) {{ :order => "123\n456", :target => '/etc/motd' }}
+
+      it 'should fail' do
+        expect { should }.to raise_error(Puppet::Error, /cannot contain/)
+      end
+    end
   end # order =>
 
   context 'more than one content source' do


### PR DESCRIPTION
Per discussion on #272, we're going to validate $order rather than worry
about needing to make substitutions on it.