### PR TITLE
Fixup $order parameter verification

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -42,7 +42,7 @@ define concat::fragment(
   }
   if !(is_string($order) or is_integer($order)) {
     fail('$order is not a string or integer.')
-  } elsif $order =~ /[:\n\/]/ {
+  } elsif (is_string($order) and $order =~ /[:\n\/]/) {
     fail("Order cannot contain '/', ':', or '\n'.")
   }
   if $mode {


### PR DESCRIPTION
When testing the order parameter on sanity, make sure that
pattern matching is only exercised on strings. Integers
don't like that.

Without the patch, and integer passed, you end up with below error and aborted catalog like this:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Left match operand must result in a String value. Got an Integer. at /etc/puppet/environments/production/modules/concat/manifests/fragment.pp:45:11 on node XXX
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
