### PR TITLE
Add show_diff to concat/concat::fragment resources.

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -23,20 +23,24 @@
 #   Deprecated
 # [*backup*]
 #   Deprecated
+# [*show_diff*]
+#   Boolean whether to show fragment-diffs or not.
 #
 define concat::fragment(
     $target,
-    $content = undef,
-    $source  = undef,
-    $order   = '10',
-    $ensure  = undef,
-    $mode    = undef,
-    $owner   = undef,
-    $group   = undef,
-    $backup  = undef
+    $content   = undef,
+    $source    = undef,
+    $order     = '10',
+    $ensure    = undef,
+    $mode      = undef,
+    $owner     = undef,
+    $group     = undef,
+    $backup    = undef,
+    $show_diff = true
 ) {
   validate_string($target)
   validate_string($content)
+  validate_bool($show_diff)
   if !(is_string($source) or is_array($source)) {
     fail('$source is not a string or an Array.')
   }
@@ -111,14 +115,15 @@ define concat::fragment(
   # punt on group ownership until some point in the distant future when $::gid
   # can be relied on to be present
   file { "${fragdir}/fragments/${order}_${safe_name}":
-    ensure  => $safe_ensure,
-    owner   => $fragowner,
-    mode    => $fragmode,
-    source  => $source,
-    content => $content,
-    backup  => false,
-    replace => true,
-    alias   => "concat_fragment_${name}",
-    notify  => Exec["concat_${target}"]
+    ensure    => $safe_ensure,
+    owner     => $fragowner,
+    mode      => $fragmode,
+    source    => $source,
+    content   => $content,
+    backup    => false,
+    replace   => true,
+    show_diff => $show_diff,
+    alias     => "concat_fragment_${name}",
+    notify    => Exec["concat_${target}"]
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,8 @@
 # [*ensure_newline*]
 # [*gnu*]
 #   Deprecated
+# [*show_diff*]
+#   Boolean whether or not to show diffs.
 #
 # === Actions:
 # * Creates fragment directories if it didn't exist already
@@ -65,7 +67,8 @@ define concat(
   $order          = 'alpha',
   $ensure_newline = false,
   $validate_cmd   = undef,
-  $gnu            = undef
+  $gnu            = undef,
+  $show_diff      = true
 ) {
   validate_re($ensure, '^present$|^absent$')
   validate_absolute_path($path)
@@ -177,15 +180,16 @@ define concat(
     }
 
     file { $name:
-      ensure       => present,
-      owner        => $owner,
-      group        => $group,
-      mode         => $mode,
-      replace      => $replace,
-      path         => $path,
-      alias        => "concat_${name}",
-      source       => "${fragdir}/${concat_name}",
-      backup       => $backup,
+      ensure    => present,
+      owner     => $owner,
+      group     => $group,
+      mode      => $mode,
+      replace   => $replace,
+      path      => $path,
+      alias     => "concat_${name}",
+      source    => "${fragdir}/${concat_name}",
+      backup    => $backup,
+      show_diff => $show_diff,
     }
 
     # Only newer versions of puppet 3.x support the validate_cmd parameter


### PR DESCRIPTION
Allows keeping our concat diffs private during puppet runs so that
secrets are not logged.