### PR TITLE
Set script's group to 0 if script owner is root

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -37,6 +37,8 @@ class concat::setup {
 
   $script_owner = $::osfamily ? { 'windows' => undef, default => $::id }
 
+  $script_group = $script_owner ? { 'root' => '0', default => undef }
+
   $script_mode = $::osfamily ? { 'windows' => undef, default => '0755' }
 
   $script_command = $::osfamily? {
@@ -51,6 +53,7 @@ class concat::setup {
   file { $script_path:
     ensure => file,
     owner  => $script_owner,
+    group  => $script_group,
     mode   => $script_mode,
     source => "puppet:///modules/concat/${script_name}",
   }


### PR DESCRIPTION
When files on a puppetmaster are owned by a non-root user,
concatfragments.sh gets installed on the nodes with a group
owner matching the one of the master.

This has no security implications since the file is mode 755,
but does lead to possible ping-pong situations when switching
between environments where the files on the master have
different group ownership.

Use '0' instead of 'root', since the root user's main group
isn't always 'root' on some BSDs, but always '0'.