### PR TITLE
Fix breakage on OpenBSD in similar fashion as it is done for Windows.

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -43,6 +43,7 @@ class concat::setup {
 
   $script_command = $::osfamily? {
     'windows' => "ruby.exe '${script_path}'",
+    'openbsd' => "/usr/local/bin/ruby21 '${script_path}'",
     default   => $script_path
   }
 


### PR DESCRIPTION
Broken since the switch from the shell script to the ruby script.

I did something stupid with git while trying to rebase, this is the same as what I had in #276, fixing the breakage introduced with the switch from concatfragments.sh to concatfragments.rb