### PR TITLE
setup: set user/group explicitly for dirs & script

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -35,9 +35,9 @@ class concat::setup {
 
   $script_path = "${concatdir}/bin/${script_name}"
 
-  $script_owner = $::osfamily ? { 'windows' => undef, default => $::id }
+  $default_owner = $::osfamily ? { 'windows' => undef, default => $::id }
 
-  $script_group = $script_owner ? { 'root' => '0', default => undef }
+  $default_group = $default_owner ? { 'root' => '0', default => undef }
 
   $script_mode = $::osfamily ? { 'windows' => undef, default => '0755' }
 
@@ -52,14 +52,16 @@ class concat::setup {
 
   file { $script_path:
     ensure => file,
-    owner  => $script_owner,
-    group  => $script_group,
+    owner  => $default_owner,
+    group  => $default_group,
     mode   => $script_mode,
     source => "puppet:///modules/concat/${script_name}",
   }
 
   file { [ $concatdir, "${concatdir}/bin" ]:
     ensure => directory,
+    owner  => $default_owner,
+    group  => $default_group,
     mode   => '0755',
   }
 }

--- a/spec/unit/classes/concat_setup_spec.rb
+++ b/spec/unit/classes/concat_setup_spec.rb
@@ -18,6 +18,8 @@ describe 'concat::setup', :type => :class do
     it do
       should contain_file("#{concatdir}/bin/concatfragments.rb").with({
         :mode   => '0755',
+        :owner  => 'root',
+        :group  => 0,
         :source => 'puppet:///modules/concat/concatfragments.rb',
         :backup => false,
       })
@@ -28,6 +30,8 @@ describe 'concat::setup', :type => :class do
         should contain_file(file).with({
           :ensure => 'directory',
           :mode   => '0755',
+	      :owner  => 'root',
+          :group  => 0,
           :backup => false,
         })
       end
@@ -64,6 +68,7 @@ describe 'concat::setup', :type => :class do
       should contain_file("#{concatdir}/bin/concatfragments.rb").with({
         :ensure => 'file',
         :owner  => 'root',
+        :group  => 0,
         :mode   => '0755',
         :source => 'puppet:///modules/concat/concatfragments.rb',
         :backup => false,
@@ -87,6 +92,7 @@ describe 'concat::setup', :type => :class do
       should contain_file("#{concatdir}/bin/concatfragments.rb").with({
         :ensure => 'file',
         :owner  => nil,
+        :group  => nil,
         :mode   => nil,
         :source => 'puppet:///modules/concat/concatfragments.rb',
         :backup => false,

--- a/spec/unit/classes/concat_setup_spec.rb
+++ b/spec/unit/classes/concat_setup_spec.rb
@@ -30,7 +30,7 @@ describe 'concat::setup', :type => :class do
         should contain_file(file).with({
           :ensure => 'directory',
           :mode   => '0755',
-	      :owner  => 'root',
+          :owner  => 'root',
           :group  => 0,
           :backup => false,
         })


### PR DESCRIPTION
Hi,

I think user and group properties need to be set explicitly for the concat *runtime environment* (base dir and script).
As Puppet propagates resources defaults to included modules, declaring something like

```puppet
File {
  owner => bind,
  group => root
}
```
in a module makes concat create its basedir belonging to user `bind`.

Jérôme