### PR TITLE
Revert and fix regex

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -44,7 +44,7 @@ define concat::fragment(
     fail("Can't use 'source' and 'content' at the same time")
   }
 
-  $safe_target_name = regsubst($target, '[/:\n\s\\]', '_', 'GM')
+  $safe_target_name = regsubst($target, '[/:\n\s]', '_', 'GM')
 
   file_fragment { $name:
     tag     => $safe_target_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,7 @@ define concat(
     warning('The $force parameter to concat is deprecated and has no effect.')
   }
 
-  $safe_name            = regsubst($name, '[/:\n\s\\]', '_', 'G')
+  $safe_name            = regsubst($name, '[/:\n\s]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"
 
   case $warn {


### PR DESCRIPTION
Commit: 6cfa62bce433f44c4ea6279adcb886e038e44df1 
Issue: #296 
seems to have broken regex on Linux (Ubuntu 14.04, Puppet 3.7.5):

Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, regsubst(): Bad regular expression `[/:\n\s\\]' at /etc/puppet/environments/development/modules/concat/manifests/init.pp:77:27

Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, regsubst(): Bad regular expression `[/:\n\s\\]' at /etc/puppet/environments/development/modules/concat/manifests/fragment.pp:47:23