### PR TITLE
(maint) fixup invalid JSON

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -105,6 +105,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 5.0.0"}
   ]
 }


### PR DESCRIPTION
Previously there was a trailing comma after the last item in a list.
That is invalid in JSON. This commit removes that one comma.