### PR TITLE
fix fragment target handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Specifies a file to read into the content of the fragment. **Note**: You must su
 
 #####`target`
 
-*Required.* Specifies the destination file of the fragment. Valid options: a string containing an absolute path.
+*Required.* Specifies the destination file of the fragment. Valid options: a string containing the title of the parent `concat` resource.
 
 
 ####Type: `concat_file`
@@ -279,7 +279,7 @@ Specifies a file to read into the content of the fragment. **Note**: You must su
 
 #####`target`
 
-*Required.* Specifies the destination file of the fragment. Valid options: a string containing an absolute path.
+*Required.* Specifies the destination file of the fragment. Valid options: a string containing the title of the parent `concat_file` resource.
 
 ###Removed functionality
 

--- a/lib/puppet/type/concat_fragment.rb
+++ b/lib/puppet/type/concat_fragment.rb
@@ -17,6 +17,10 @@ Puppet::Type.newtype(:concat_fragment) do
     desc "Unique name"
   end
 
+  newparam(:target) do
+    desc "Target"
+  end
+
   newparam(:content) do
     desc "Content"
   end
@@ -38,7 +42,19 @@ Puppet::Type.newtype(:concat_fragment) do
     desc "Tag name to be used by concat to collect all concat_fragments by tag name"
   end
 
+  autorequire(:file) do
+    unless catalog.resource("Concat_file[#{self[:target]}]")
+      warning "Target Concat_file[#{self[:target]}] not found in the catalog"
+    end
+  end
+
   validate do
+    # Check if target is set
+    fail Puppet::ParseError, "Target not set" if self[:target].nil?
+
+    # Check if tag is set
+    fail Puppet::ParseError, "Tag not set" if self[:tag].nil?
+
     # Check if either source or content is set. raise error if none is set
     fail Puppet::ParseError, "Set either 'source' or 'content'" if self[:source].nil? && self[:content].nil?
 

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -47,6 +47,7 @@ define concat::fragment(
   $safe_target_name = regsubst($target, '[/:\n\s]', '_', 'GM')
 
   concat_fragment { $name:
+    target  => $target,
     tag     => $safe_target_name,
     order   => $order,
     content => $content,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,6 +107,7 @@ define concat(
 
     if $_append_header {
       concat_fragment { "${name}_header":
+        target  => $name,
         tag     => $safe_name,
         content => $warn_message,
         order   => '0',

--- a/spec/acceptance/warnings_spec.rb
+++ b/spec/acceptance/warnings_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'deprecation warnings' do
+describe 'warnings' do
   basedir = default.tmpdir('concat')
 
   shared_examples 'has_warning' do |pp, w|
@@ -10,7 +10,7 @@ describe 'deprecation warnings' do
     end
   end
 
-  context 'concat force parameter' do
+  context 'concat force parameter deprecation' do
     pp = <<-EOS
       concat { '#{basedir}/file':
         force => false,
@@ -25,7 +25,7 @@ describe 'deprecation warnings' do
     it_behaves_like 'has_warning', pp, w
   end
 
-  context 'concat::fragment ensure parameter' do
+  context 'concat::fragment ensure parameter deprecation' do
     context 'target file exists' do
     pp = <<-EOS
       concat { '#{basedir}/file':
@@ -37,6 +37,23 @@ describe 'deprecation warnings' do
       }
     EOS
     w = 'The $ensure parameter to concat::fragment is deprecated and has no effect.'
+
+    it_behaves_like 'has_warning', pp, w
+    end
+  end
+
+  context 'concat::fragment target not found' do
+    context 'target not found' do
+    pp = <<-EOS
+      concat { 'file':
+        path => '#{basedir}/file',
+      }
+      concat::fragment { 'foo':
+        target  => '#{basedir}/file',
+        content => 'bar',
+      }
+    EOS
+    w = 'not found in the catalog'
 
     it_behaves_like 'has_warning', pp, w
     end


### PR DESCRIPTION
Needed to bind fragment targets to it's parent concat resource's title so that we can
find them in the catalog. Throws a warning if the target is not found.