### PR TITLE
adds file autorequire

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -89,6 +89,22 @@ Puppet::Type.newtype(:concat_file) do
     end.compact
   end
 
+  # Copied from puppet's file type
+  # Autorequire the nearest ancestor directory found in the catalog.
+  autorequire(:file) do
+    req = []
+    path = Pathname.new(self[:path])
+    if !path.root?
+      # Start at our parent, to avoid autorequiring ourself
+      parents = path.parent.enum_for(:ascend)
+      if found = parents.find { |p| catalog.resource(:file, p.to_s) }
+        req << found.to_s
+      end
+    end
+
+    req
+  end
+
   def should_content
     return @generated_content if @generated_content
     @generated_content = ""


### PR DESCRIPTION
autorequire will add parent directories of the concat_file to the dependency chain.
So they can be created in the right order if they do not exist.