### PR TITLE
(MODULES-2080) Call out changed behaviour of 'warn' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,12 @@ Specifies whether to add a header message at the top of the destination file. Va
 If you set 'warn' to 'true', `concat` adds the following message:
 
 ~~~
-# This file is managed by Puppet. DO NOT EDIT.
+# This file is managed by Puppet. DO NOT EDIT.\n
 ~~~
+
+Before 2.0.0, this parameter would add a newline at the end of the warn
+message. To improve flexibilty, this was removed. Please add it explicitely if
+you need it.
 
 ####Define: `concat::fragment`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,10 @@
 #   The mode of the final file
 # [*warn*]
 #   Adds a normal shell style comment top of the file indicating that it is
-#   built by puppet
+#   built by puppet.
+#   Before 2.0.0, this parameter would add a newline at the end of the warn
+#   message. To improve flexibilty, this was removed. Please add it explicitely
+#   if you need it.
 # [*backup*]
 #   Controls the filebucketing behavior of the final file and see File type
 #   reference for its use.  Defaults to 'puppet'


### PR DESCRIPTION
Before 2.0.0, this parameter would add a newline at the end of the warn
message. To improve flexibilty, this was removed. Please add it
explicitely if you need it.