### PR TITLE
fix defaulted force behavior

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -163,7 +163,11 @@ Puppet::Type.newtype(:concat_file) do
   end
 
   def eval_generate
-    catalog.resource("File[#{self[:path]}]")[:content] = should_content
+    content = should_content
+
+    if !content.nil? and !content.empty?
+      catalog.resource("File[#{self[:path]}]")[:content] = content
+    end
     []
   end
 end


### PR DESCRIPTION
With Concat 2.0.x we've deprecated the -force parameter and the resulting bug
caused concat files that have no content/fragments to overwrite the target file with an
empty file. Concat should only create an empty file if no file exists, and if the file
exists, then it should not overwrite it with an empty file.