### PR TITLE
(MODULES-2094) Extend regexp to remove parenthesis on safe names

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -44,7 +44,7 @@ define concat::fragment(
     fail("Can't use 'source' and 'content' at the same time")
   }
 
-  $safe_target_name = regsubst($target, '[/:\n\s]', '_', 'GM')
+  $safe_target_name = regsubst($target, '[/:\n\s\(\)]', '_', 'GM')
 
   concat_fragment { $name:
     tag     => $safe_target_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@ define concat(
     warning('The $force parameter to concat is deprecated and has no effect.')
   }
 
-  $safe_name            = regsubst($name, '[/:\n\s]', '_', 'G')
+  $safe_name            = regsubst($name, '[/:\n\s\(\)]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"
 
   case $warn {


### PR DESCRIPTION
This patch allows concatenation on folders like `C:\Program Files (x86)` on Windows agents.