### PR TITLE
(MODULES-2023) - autorequire the file we are generating

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -89,20 +89,9 @@ Puppet::Type.newtype(:concat_file) do
     end.compact
   end
 
-  # Copied from puppet's file type
-  # Autorequire the nearest ancestor directory found in the catalog.
+  # Autorequire the file we are generating below
   autorequire(:file) do
-    req = []
-    path = Pathname.new(self[:path])
-    if !path.root?
-      # Start at our parent, to avoid autorequiring ourself
-      parents = path.parent.enum_for(:ascend)
-      if found = parents.find { |p| catalog.resource(:file, p.to_s) }
-        req << found.to_s
-      end
-    end
-
-    req
+    [self[:path]]
   end
 
   def should_content


### PR DESCRIPTION
concat_file generates a file resource which will manage the content,
while the interface for requirements is Concat[] or at least
Concat_file[]. The file is currently flowing within the graph
without any dependency. However, so that require and notifies are
working properly, the file must be present before the concat_file
resource is finished being managed and potentially other resources
depending on that one are being managed.

This also makes the copy & paste from looking for the parent
directory as originaly described within MODULES-2023 obsolete, as
this will be handled by the file itself.