### PR TITLE
Associate fragments by path, not tag

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -30,15 +30,7 @@ Puppet::Type.newtype(:concat_file) do
     self[:ensure] == :present
   end
 
-  newparam(:name, :namevar => true) do
-    desc "Resource name"
-  end
-
-  newparam(:tag) do
-    desc "Tag reference to collect all concat_fragment's with the same tag"
-  end
-
-  newparam(:path) do
+  newparam(:path, :namevar => true) do
     desc "The output file"
     defaultto do
       resource.value(:name)
@@ -83,7 +75,7 @@ Puppet::Type.newtype(:concat_file) do
 
   autorequire(:concat_fragment) do
     catalog.resources.collect do |r|
-      if r.is_a?(Puppet::Type.type(:concat_fragment)) && r[:tag] == self[:tag]
+      if r.is_a?(Puppet::Type.type(:concat_fragment)) && r[:target] == self[:path]
         r.name
       end
     end.compact
@@ -100,7 +92,7 @@ Puppet::Type.newtype(:concat_file) do
     content_fragments = []
 
     resources = catalog.resources.select do |r|
-      r.is_a?(Puppet::Type.type(:concat_fragment)) && r[:tag] == self[:tag]
+      r.is_a?(Puppet::Type.type(:concat_fragment)) && r[:target] == self[:path]
     end
 
     resources.each do |r|

--- a/lib/puppet/type/concat_fragment.rb
+++ b/lib/puppet/type/concat_fragment.rb
@@ -38,10 +38,6 @@ Puppet::Type.newtype(:concat_fragment) do
     end
   end
 
-  newparam(:tag) do
-    desc "Tag name to be used by concat to collect all concat_fragments by tag name"
-  end
-
   autorequire(:file) do
     unless catalog.resource("Concat_file[#{self[:target]}]")
       warning "Target Concat_file[#{self[:target]}] not found in the catalog"


### PR DESCRIPTION
Previously tag was declared as a parameter for concat_file and also concat_fragment (also the name of a metaparameter), and the tag value was used to associate concat_fragment resources with their concat_file collector.

ANAICT this was an unnecessarily brittle means of associating collections. Basing association on tags effectively relied on the end user not using the tag parameter, which is not a safe assumption given that "tag" is also a useful metaparameter.

This commit makes path the namevar of the concat_file type and changes the association to be between the concat_file-path and
concat_fragment-target parameters.