### PR TITLE
Add support for Solaris 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ The `concat::setup` class should no longer be directly included in the manifest.
 
 ##Limitations
 
-This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified.
+This module has been tested on [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix), and no issues have been identified. Additionally, it is tested (but not supported) on Solaris 12.
 
 ##Development
 

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,8 @@
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
         "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {


### PR DESCRIPTION
Fairly self-explanatory. This simply adds Solaris 12 to metadata.json.
