### PR TITLE
(#2208) FreeBSD: call /usr/local/bin/ruby explicitly

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -44,6 +44,7 @@ class concat::setup {
   $script_command = $::osfamily? {
     'windows' => "ruby.exe '${script_path}'",
     'openbsd' => "/usr/local/bin/ruby21 '${script_path}'",
+    'freebsd' => "/usr/local/bin/ruby '${script_path}'",
     default   => $script_path
   }
 


### PR DESCRIPTION
On FreeBSD systems, the Ruby interpreter is normally installed in
/usr/local/bin, which is not on the default PATH when running init
scripts.  Most users will have it in their PATH when logged in, which
causes concat to fail when run from init (or "service puppet start")
but not when run from directly the command line ("sudo puppet agent").
This follows the same strategy as OpenBSD, but avoid specifying the
Ruby interpreter version explicitly, because FreeBSD supports three
different versions of Ruby (with the default always being installed as
/usr/local/bin/ruby).