### PR TITLE
Fixing tests for puppet < 3.5

### DIFF
--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -46,13 +46,21 @@ describe 'concat::fragment', :type => :define do
       should contain_file("#{fragdir}/fragments/#{p[:order]}_#{safe_name}").with({
         :ensure  => safe_ensure,
         :owner   => id,
-        :group   => gid,
         :mode    => '0640',
         :source  => p[:source],
         :content => p[:content],
         :alias   => "concat_fragment_#{title}",
         :backup  => 'puppet',
       })
+      # The defined() function doesn't seem to work properly with puppet 3.4 and rspec.
+      # defined() works on its own, rspec works on its own, but together they
+      # determine that $gid is not defined and cause errors here. Work around
+      # it by ignoring this check for older puppet version.
+      if Puppet::Util::Package.versioncmp(Puppet.version, '3.5.0') >= 0
+        should contain_file("#{fragdir}/fragments/#{p[:order]}_#{safe_name}").with({
+          :group   => gid,
+        })
+      end
     end
   end
 

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -383,16 +383,18 @@ describe 'concat', :type => :define do
   end # ensure_newline =>
 
   context 'validate_cmd =>' do
-    context '/usr/bin/test -e %' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :validate_cmd => '/usr/bin/test -e %' }
-    end
+    if Puppet::Util::Package::versioncmp(Puppet::version, '3.5.0') > 0
+      context '/usr/bin/test -e %' do
+        it_behaves_like 'concat', '/etc/foo.bar', { :validate_cmd => '/usr/bin/test -e %' }
+      end
 
-    [ 1234, true ].each do |cmd|
-      context cmd do
-        let(:title) { '/etc/foo.bar' }
-        let(:params) {{ :validate_cmd => cmd }}
-        it 'should fail' do
-          expect { should }.to raise_error(Puppet::Error, /\$validate_cmd must be a string/)
+      [ 1234, true ].each do |cmd|
+        context cmd do
+          let(:title) { '/etc/foo.bar' }
+          let(:params) {{ :validate_cmd => cmd }}
+          it 'should fail' do
+            expect { should }.to raise_error(Puppet::Error, /\$validate_cmd must be a string/)
+          end
         end
       end
     end


### PR DESCRIPTION
This change addresses MODULES-2115 and is a backport of the fixes that
were included as part of #340.