### PR TITLE
Recent OpenBSD changed to ruby22 as default interpreter, that now

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -43,7 +43,10 @@ class concat::setup {
 
   $script_command = $::osfamily? {
     'windows' => "ruby.exe '${script_path}'",
-    'openbsd' => "/usr/local/bin/ruby21 '${script_path}'",
+    'openbsd' => $::kernelversion ? {
+                    '5.7'   => "/usr/local/bin/ruby21 '${script_path}'",
+                    default => "/usr/local/bin/ruby22 '${script_path}'"
+                  },
     'freebsd' => "/usr/local/bin/ruby '${script_path}'",
     default   => $script_path
   }


### PR DESCRIPTION
is also used by Puppet, so adapt to that.

Tested on OpenBSD 5.8-beta, and 5.7-snapshot.

Using ::kernelversion instead of ::operatingsystemrelease, because
::operatingsystemrelease can be 5.7, 5.8, 5.7-snapshot, 5.8-beta etc.

Note that it was myself that introduced the /usr/local/bin/ruby21 interpreter in the module here with OpenBSD 5.7 a few month ago. Since it's there untouched, I doubt anyone is using it with older versions of OpenBSD, and therefore I don't think its worth caring about them.

Let me know if I can change/enhance anything, otherwise, pleae consider for merge.

cheers,
Sebastian

