### PR TITLE
Backup option breaks concat

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -58,12 +58,6 @@ define concat::fragment(
     warning('The $backup parameter to concat::fragment is deprecated and has no effect')
   }
 
-  $my_backup = concat_getparam(Concat[$target], 'backup')
-  $_backup = $my_backup ? {
-    ''      => undef,
-    default => $my_backup
-  }
-
   if $ensure == undef {
     $my_ensure = concat_getparam(Concat[$target], 'ensure')
   } else {
@@ -125,7 +119,7 @@ define concat::fragment(
     mode    => $fragmode,
     source  => $source,
     content => $content,
-    backup  => $_backup,
+    backup  => false,
     replace => true,
     alias   => "concat_fragment_${name}",
     notify  => Exec["concat_${target}"]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,10 +146,6 @@ define concat(
     false => '',
   }
 
-  File {
-    backup  => $backup,
-  }
-
   # reset poisoned Exec defaults
   Exec {
     user  => undef,
@@ -168,6 +164,7 @@ define concat(
       force   => true,
       ignore  => ['.svn', '.git', '.gitignore'],
       notify  => Exec["concat_${name}"],
+      backup  => false,
       purge   => true,
       recurse => true,
     }

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -50,7 +50,7 @@ describe 'concat::fragment', :type => :define do
         :source  => p[:source],
         :content => p[:content],
         :alias   => "concat_fragment_#{title}",
-        :backup  => 'puppet',
+        :backup  => false,
       })
       # The defined() function doesn't seem to work properly with puppet 3.4 and rspec.
       # defined() works on its own, rspec works on its own, but together they

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -28,10 +28,6 @@ describe 'concat', :type => :define do
     concat_name          = 'fragments.concat.out'
     default_warn_message = '# This file is managed by Puppet. DO NOT EDIT.'
 
-    file_defaults = {
-      :backup  => p[:backup],
-    }
-
     let(:title) { title }
     let(:params) { params }
     let(:facts) do
@@ -47,21 +43,22 @@ describe 'concat', :type => :define do
 
     if p[:ensure] == 'present'
       it do
-        should contain_file(fragdir).with(file_defaults.merge({
+        should contain_file(fragdir).with({
           :ensure => 'directory',
           :mode   => '0750',
-        }))
+        })
       end
 
       it do
-        should contain_file("#{fragdir}/fragments").with(file_defaults.merge({
+        should contain_file("#{fragdir}/fragments").with({
           :ensure  => 'directory',
           :mode    => '0750',
           :force   => true,
           :ignore  => ['.svn', '.git', '.gitignore'],
+          :backup  => false,
           :purge   => true,
           :recurse => true,
-        }))
+        })
       end
 
       [
@@ -69,15 +66,15 @@ describe 'concat', :type => :define do
         "#{fragdir}/#{concat_name}",
       ].each do |file|
         it do
-          should contain_file(file).with(file_defaults.merge({
+          should contain_file(file).with({
             :ensure => 'present',
             :mode   => '0640',
-          }))
+          })
         end
       end
 
       it do
-        should contain_file(title).with(file_defaults.merge({
+        should contain_file(title).with({
           :ensure       => 'present',
           :owner        => p[:owner],
           :group        => p[:group],
@@ -88,7 +85,7 @@ describe 'concat', :type => :define do
           :source       => "#{fragdir}/#{concat_name}",
           :validate_cmd => p[:validate_cmd],
           :backup       => p[:backup],
-        }))
+        })
       end
 
       cmd = "#{concatdir}/bin/concatfragments.rb " +
@@ -136,18 +133,18 @@ describe 'concat', :type => :define do
         "#{fragdir}/#{concat_name}",
       ].each do |file|
         it do
-          should contain_file(file).with(file_defaults.merge({
+          should contain_file(file).with({
             :ensure => 'absent',
             :force  => true,
-          }))
+          })
         end
       end
 
       it do
-        should contain_file(title).with(file_defaults.merge({
+        should contain_file(title).with({
           :ensure => 'absent',
           :backup => p[:backup],
-        }))
+        })
       end
 
       it do


### PR DESCRIPTION
The backup option, provided to the `concat` resource is used to backup the final target file before overwritting it.
Problem is: the backup option is used for the concat fragments file resources and, even worse, the fragments directory.
It means that, when `backup` is enabled (say ".bak") and a fragment changes, the file is first backed up inside the fragment dir, then removed (directory has purge, recurse set to true), but backed up again because the `File[/var/lib/puppet/concat/_target_file]` also has `backup => ".bak"` !

**The final concatenated file results in the fragment appearing twice !**

Pull request fixes this issue.
I've been able to update unit test, but I can't run the acceptance ones. Maybe they need to be updated as well.
Please consider this before the 1.2.4 release, I think this is a really serious bug.

Thank you