### PR TITLE
(MODULES-2572) Fix acceptance test vagrant URLs

### DIFF
--- a/spec/acceptance/nodesets/centos-59-x64.yml
+++ b/spec/acceptance/nodesets/centos-59-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: el-5-x86_64
     box : centos-59-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-59-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/centos-59-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: git

--- a/spec/acceptance/nodesets/centos-64-x64-pe.yml
+++ b/spec/acceptance/nodesets/centos-64-x64-pe.yml
@@ -6,7 +6,7 @@ HOSTS:
       - dashboard
     platform: el-6-x86_64
     box : centos-64-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/centos-64-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: pe

--- a/spec/acceptance/nodesets/centos-64-x64.yml
+++ b/spec/acceptance/nodesets/centos-64-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: el-6-x86_64
     box : centos-64-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/centos-64-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: git

--- a/spec/acceptance/nodesets/centos-65-x64.yml
+++ b/spec/acceptance/nodesets/centos-65-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: el-6-x86_64
     box : centos-65-x64-vbox436-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/centos-65-x64-virtualbox-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/debian-607-x64.yml
+++ b/spec/acceptance/nodesets/debian-607-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: debian-6-amd64
     box : debian-607-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/debian-607-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: git

--- a/spec/acceptance/nodesets/debian-70rc1-x64.yml
+++ b/spec/acceptance/nodesets/debian-70rc1-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: debian-7-amd64
     box : debian-70rc1-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-70rc1-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/debian-70rc1-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: git

--- a/spec/acceptance/nodesets/debian-73-x64.yml
+++ b/spec/acceptance/nodesets/debian-73-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: debian-7-amd64
     box : debian-73-x64-virtualbox-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/debian-73-x64-virtualbox-nocm.box
     hypervisor : vagrant
 CONFIG:
   log_level: debug

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: el-6-x86_64
     box : puppetlabs/centos-6.6-64-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-6.6-64-nocm
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/centos-6.6-64-nocm
     hypervisor : vagrant
 CONFIG:
   type: git

--- a/spec/acceptance/nodesets/fedora-18-x64.yml
+++ b/spec/acceptance/nodesets/fedora-18-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: fedora-18-x86_64
     box : fedora-18-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/fedora-18-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/fedora-18-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: git

--- a/spec/acceptance/nodesets/sles-11-x64.yml
+++ b/spec/acceptance/nodesets/sles-11-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: sles-11-x64
     box : sles-11sp1-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/sles-11sp1-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/sles-11sp1-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
     type: foss

--- a/spec/acceptance/nodesets/sles-11sp1-x64.yml
+++ b/spec/acceptance/nodesets/sles-11sp1-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: sles-11-x86_64
     box : sles-11sp1-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/sles-11sp1-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/sles-11sp1-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: git

--- a/spec/acceptance/nodesets/ubuntu-server-10044-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-10044-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: ubuntu-10.04-amd64
     box : ubuntu-server-10044-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-server-10044-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
@@ -4,7 +4,7 @@ HOSTS:
       - master
     platform: ubuntu-12.04-amd64
     box : ubuntu-server-12042-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box
+    box_url : https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-server-12042-x64-vbox4210-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: foss


### PR DESCRIPTION
The vagrant boxes at puppet-vagrant-boxes.puppetlabs.com were removed a
few months ago in favor of those hosted at atlas.hashicorp.com. This
switches the acceptance test nodesets to specify the correct URL which
makes it possible to manually run the acceptance tests.