### PR TITLE
Allow integer UID/GID for $owner/$group

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,9 +73,13 @@ define concat(
 ) {
   validate_re($ensure, '^present$|^absent$')
   validate_absolute_path($path)
-  validate_string($owner)
-  validate_string($group)
   validate_string($mode)
+  if ! (is_string($owner) or is_integer($owner)) {
+    fail("\$owner must be a string or integer, got ${owner}")
+  }
+  if ! (is_string($group) or is_integer($group)) {
+    fail("\$group must be a string or integer, got ${group}")
+  }
   if ! (is_string($warn) or $warn == true or $warn == false) {
     fail('$warn is not a string or boolean')
   }

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -229,11 +229,15 @@ describe 'concat', :type => :define do
       it_behaves_like 'concat', '/etc/foo.bar', { :owner => 'apenny' }
     end
 
+    context '1000' do
+      it_behaves_like 'concat', '/etc/foo.bar', { :owner => 1000 }
+    end
+
     context 'false' do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :owner => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
+        expect { catalogue }.to raise_error(Puppet::Error, /\$owner must be a string or integer/)
       end
     end
   end # owner =>
@@ -243,11 +247,15 @@ describe 'concat', :type => :define do
       it_behaves_like 'concat', '/etc/foo.bar', { :group => 'apenny' }
     end
 
+    context '1000' do
+      it_behaves_like 'concat', '/etc/foo.bar', { :group => 1000 }
+    end
+
     context 'false' do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :group => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
+        expect { catalogue }.to raise_error(Puppet::Error, /\$group must be a string or integer/)
       end
     end
   end # group =>


### PR DESCRIPTION
This allows specifying a numerical user ID or group ID for the $owner
and $group parameters, respectively. Currently, only string values for
the user name and group name are allowed, but these parameters are
passed straight to the file resource that is created, which supports
both string name and numeric ID.