### PR TITLE
fixes resource reference in concat_file eval_generate return

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -173,6 +173,7 @@ Puppet::Type.newtype(:concat_file) do
     if !content.nil? and !content.empty?
       catalog.resource("File[#{self[:path]}]")[:content] = content
     end
-    [ catalog.resource("File[#{self[:name]}]") ]
+
+    [ catalog.resource("File[#{self[:path]}]") ]
   end
 end


### PR DESCRIPTION
Need to use :path instead of :name, as path is the namevar of the File resource.