### PR TITLE
Fix line endings on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.sh  eol=lf
+*.rb  eol=lf


### PR DESCRIPTION
7eb14b77 removed files/concatfragments.sh and used concatfragments.rb instead. #80 fixed the issue i have for the former .sh file, this PR fixes it for the new .rb file.

actually, this changes the line endings for all .rb files. i don't know whether that's the right way to go...
