### PR TITLE
Fix the minimum required stdlib version to 4.2.0.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-concat",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 < 5.0.0"}
   ],
   "data_provider": null,
   "operatingsystem_support": [


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-concat/commit/f4241b5ffea66e69d9c51fa3ae327fdcd379013f referenced is_bool() from stdlib that was only added in 4.2.0, according to: https://github.com/puppetlabs/puppetlabs-stdlib/blob/04fa5a0cd9255dc2d51af517be7164db9ea0306b/CHANGELOG.md