### PR TITLE
(MODULES-3097) Re-fix fragment sorting by alpha

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -136,8 +136,9 @@ Puppet::Type.newtype(:concat_file) do
         decompound(a[0]) <=> decompound(b[0])
       end
     else
-      sorted = content_fragments.sort do |a, b|
-        a[0] <=> b[0]
+      sorted = content_fragments.sort_by do |a|
+        a_order, a_name = a[0].split('__')
+        [a_order, a_name]
       end
     end
 


### PR DESCRIPTION
This is a fix for the fix provided in #391, which was still not working correctly for alpha sorting.

When given an array of fragments that results in:

`["1__string1", "2__string2", "10__string10"]`

The correct alpha ordering/sorting should be:

`["1__string1", "10__string10", "2__string2"]`

The previous fix in PR #391 resulted in:

`["10__string10", "1__string1", "2__string2"]`