### PR TITLE
MODULES-3156: propagate the validate_cmd to the file resource

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -186,6 +186,7 @@ Puppet::Type.newtype(:concat_file) do
      :selrole,
      :seltype,
      :seluser,
+     :validate_cmd,
      :show_diff].each do |param|
       unless self[param].nil?
         file_opts[param] = self[param]


### PR DESCRIPTION
At the moment `validate_cmd` does nothing because it isn't propagated to the `file` resource.