### PR TITLE
Neiter ~ or + are allowed in tag names

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -44,7 +44,7 @@ define concat::fragment(
     fail("Can't use 'source' and 'content' at the same time")
   }
 
-  $safe_target_name = regsubst($target, '[/:\n\s\*\(\)]', '_', 'GM')
+  $safe_target_name = regsubst($target, '[/:~\n\s\+\*\(\)]', '_', 'GM')
 
   concat_fragment { $name:
     target  => $target,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,7 +101,7 @@ define concat(
   validate_string($seltype)
   validate_string($seluser)
 
-  $safe_name            = regsubst($name, '[/:\n\s\*\(\)]', '_', 'G')
+  $safe_name            = regsubst($name, '[/:~\n\s\+\*\(\)]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"
 
   case $warn {
@@ -156,4 +156,3 @@ define concat(
     }
   }
 }
-


### PR DESCRIPTION
Maybe this should be fixed by just replacing any non word character instead. Up to you :)