### PR TITLE
(MODULES-3332 ) Correct the path validation.

### DIFF
--- a/lib/puppet/type/concat_fragment.rb
+++ b/lib/puppet/type/concat_fragment.rb
@@ -43,8 +43,8 @@ Puppet::Type.newtype(:concat_fragment) do
   end
 
   autorequire(:file) do
-    unless catalog.resource("Concat_file[#{self[:target]}]")
-      warning "Target Concat_file[#{self[:target]}] not found in the catalog"
+    if catalog.resources.select {|x| x.class == Puppet::Type::Concat_file and x[:path] == self[:target] }.empty?
+      warning "Target Concat_file with path of #{self[:target]} not found in the catalog"
     end
   end
 

--- a/spec/acceptance/warnings_spec.rb
+++ b/spec/acceptance/warnings_spec.rb
@@ -49,7 +49,7 @@ describe 'warnings' do
         path => '#{basedir}/file',
       }
       concat::fragment { 'foo':
-        target  => '#{basedir}/file',
+        target  => '#{basedir}/bar',
         content => 'bar',
       }
     EOS


### PR DESCRIPTION
Prior to this commit, the validation would check for a `Concat_file` with the same **title** as the fragment's **path**. Unfortunately, they're not guaranteed to be the same. The `path` defaults to the `title` but can be passed in by the user.