### PR TITLE
(MODULES-3332) Correct target validation

### DIFF
--- a/lib/puppet/type/concat_fragment.rb
+++ b/lib/puppet/type/concat_fragment.rb
@@ -43,7 +43,7 @@ Puppet::Type.newtype(:concat_fragment) do
   end
 
   autorequire(:file) do
-    if catalog.resources.select {|x| x.class == Puppet::Type::Concat_file and x[:path] == self[:target] }.empty?
+    if catalog.resources.select {|x| x.class == Puppet::Type::Concat_file and (x[:path] == self[:target] || x[:name] == self[:target]) }.empty?
       warning "Target Concat_file with path of #{self[:target]} not found in the catalog"
     end
   end


### PR DESCRIPTION
The check should not warn when fragment `target` is based on `concat_file` `name` instead of `path`.
Previous fix only specifically fixed the case:
```
concat_file {'a_file': path => '/some/path'}
concat_fragment {'foo': target => '/some/path'}
```

But it introduced warnings for the case:
```
concat_file {'a_file': path => '/some/path'}
concat_fragment {'foo': target => 'a_file'}
```