### PR TITLE
tdevelioglu/refurbish

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -11,7 +11,7 @@ Puppet::Type.newtype(:concat_file) do
       Concat_fragment <<| tag == 'unique_tag' |>>
 
       concat_file { '/tmp/file':
-        tag            => 'unique_tag', # Mandatory
+        tag            => 'unique_tag', # Optional. Default to undef
         path           => '/tmp/file',  # Optional. If given it overrides the resource name
         owner          => 'root',       # Optional. Default to undef
         group          => 'root',       # Optional. Default to undef
@@ -67,7 +67,12 @@ Puppet::Type.newtype(:concat_file) do
 
   newparam(:backup) do
     desc "Controls the filebucketing behavior of the final file and see File type reference for its use."
-    defaultto 'puppet'
+
+    validate do |value|
+      unless [TrueClass, FalseClass, String].include?(value.class)
+        raise ArgumentError, 'Backup must be a Boolean or String'
+      end
+    end
   end
 
   newparam(:replace, :boolean => true, :parent => Puppet::Parameter::Boolean) do
@@ -77,6 +82,12 @@ Puppet::Type.newtype(:concat_file) do
 
   newparam(:validate_cmd) do
     desc "Validates file."
+
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'Validate_cmd must be a String'
+      end
+    end
   end
 
   newparam(:ensure_newline, :boolean => true, :parent => Puppet::Parameter::Boolean) do
@@ -85,28 +96,51 @@ Puppet::Type.newtype(:concat_file) do
   end
 
   # Inherit File parameters
-  newparam(:selinux_ignore_defaults) do
-  end
+  newparam(:selinux_ignore_defaults, :boolean => true, :parent => Puppet::Parameter::Boolean)
 
   newparam(:selrange) do
+    validate do |value|
+      raise ArgumentError, 'Selrange must be a String' unless value.is_a?(String)
+    end
   end
 
   newparam(:selrole) do
+    validate do |value|
+      raise ArgumentError, 'Selrole must be a String' unless value.is_a?(String)
+    end
   end
 
   newparam(:seltype) do
+    validate do |value|
+      raise ArgumentError, 'Seltype must be a String' unless value.is_a?(String)
+    end
   end
 
   newparam(:seluser) do
+    validate do |value|
+      raise ArgumentError, 'Seluser must be a String' unless value.is_a?(String)
+    end
   end
 
-  newparam(:show_diff) do
-  end
+  newparam(:show_diff, :boolean => true, :parent => Puppet::Parameter::Boolean)
   # End file parameters
 
   # Autorequire the file we are generating below
+  # Why is this necessary ?
   autorequire(:file) do
     [self[:path]]
+  end
+
+  def fragments
+    # Collect fragments that target this resource by path, title or tag.
+    @fragments ||= catalog.resources.map do |resource|
+      next unless resource.is_a?(Puppet::Type.type(:concat_fragment))
+
+      if resource[:target] == self[:path] || resource[:target] == title ||
+        (resource[:tag] && resource[:tag] == self[:tag])
+        resource
+      end
+    end.compact
   end
 
   def should_content
@@ -114,11 +148,7 @@ Puppet::Type.newtype(:concat_file) do
     @generated_content = ""
     content_fragments = []
 
-    resources = catalog.resources.select do |r|
-      r.is_a?(Puppet::Type.type(:concat_fragment)) && r[:tag] == self[:tag]
-    end
-
-    resources.each do |r|
+    fragments.each do |r|
       content_fragments << ["#{r[:order]}___#{r[:name]}", fragment_content(r)]
     end
 

--- a/spec/acceptance/native/backup_spec.rb
+++ b/spec/acceptance/native/backup_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_file backup parameter' do
+  basedir = default.tmpdir('concat')
+  context '=> puppet' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+        file { '#{basedir}/file':
+          content => "old contents\n",
+        }
+      EOS
+      apply_manifest(pp)
+    end
+    pp = <<-EOS
+      concat_file { '#{basedir}/file':
+        backup => 'puppet',
+      }
+      concat_fragment { 'new file':
+        target  => '#{basedir}/file',
+        content => 'new contents',
+      }
+    EOS
+
+    it 'applies the manifest twice with "Filebucketed" stdout and no stderr' do
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to match(/Filebucketed #{basedir}\/file to puppet with sum 0140c31db86293a1a1e080ce9b91305f/)
+      end
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/file") do
+      it { should be_file }
+      its(:content) { should match /new contents/ }
+    end
+  end
+
+  context '=> .backup' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+        file { '#{basedir}/file':
+          content => "old contents\n",
+        }
+      EOS
+      apply_manifest(pp)
+    end
+    pp = <<-EOS
+      concat_file { '#{basedir}/file':
+        backup => '.backup',
+      }
+      concat_fragment { 'new file':
+        target  => '#{basedir}/file',
+        content => 'new contents',
+      }
+    EOS
+
+    # XXX Puppet doesn't mention anything about filebucketing with a given
+    # extension like .backup
+    it 'applies the manifest twice  no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/file") do
+      it { should be_file }
+      its(:content) { should match /new contents/ }
+    end
+    describe file("#{basedir}/file.backup") do
+      it { should be_file }
+      its(:content) { should match /old contents/ }
+    end
+  end
+
+  # XXX The backup parameter uses validate_string() and thus can't be the
+  # boolean false value, but the string 'false' has the same effect in Puppet 3
+  context "=> 'false'" do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+        file { '#{basedir}/file':
+          content => "old contents\n",
+        }
+      EOS
+      apply_manifest(pp)
+    end
+    pp = <<-EOS
+      concat_file { '#{basedir}/file':
+        backup => '.backup',
+      }
+      concat_fragment { 'new file':
+        target  => '#{basedir}/file',
+        content => 'new contents',
+      }
+    EOS
+
+    it 'applies the manifest twice with no "Filebucketed" stdout and no stderr' do
+      apply_manifest(pp, :catch_failures => true) do |r|
+        expect(r.stdout).to_not match(/Filebucketed/)
+      end
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/file") do
+      it { should be_file }
+      its(:content) { should match /new contents/ }
+    end
+  end
+end

--- a/spec/acceptance/native/concat_spec.rb
+++ b/spec/acceptance/native/concat_spec.rb
@@ -1,0 +1,228 @@
+require 'spec_helper_acceptance'
+
+case fact('osfamily')
+  when 'AIX'
+    username = 'root'
+    groupname = 'system'
+    scriptname = 'concatfragments.rb'
+    vardir = default.puppet['vardir']
+    if vardir.nil? or vardir == ''
+      vardir = '/opt/puppetlabs/puppet/cache'
+    end
+  when 'Darwin'
+    username = 'root'
+    groupname = 'wheel'
+    scriptname = 'concatfragments.rb'
+    vardir = default.puppet['vardir']
+    if vardir.nil? or vardir == ''
+      vardir = '/opt/puppetlabs/puppet/cache'
+    end
+  when 'windows'
+    username = 'Administrator'
+    groupname = 'Administrators'
+    scriptname = 'concatfragments.rb'
+    result = on default, "echo #{default.puppet['vardir']}"
+    vardir = result.raw_output.chomp
+  when 'Solaris'
+    username = 'root'
+    groupname = 'root'
+    scriptname = 'concatfragments.rb'
+    vardir = default.puppet['vardir']
+    if vardir.nil? or vardir == ''
+      vardir = '/opt/puppetlabs/puppet/cache'
+    end
+  else
+    username = 'root'
+    groupname = 'root'
+    scriptname = 'concatfragments.rb'
+    vardir = default.puppet['vardir']
+    if vardir.nil? or vardir == ''
+      vardir = '/opt/puppetlabs/puppet/cache'
+    end
+end
+
+describe 'basic concat_file test' do
+  basedir = default.tmpdir('concat')
+  safe_basedir = basedir.gsub(/[\/:]/, '_')
+
+  shared_examples 'successfully_applied' do |pp|
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  context 'owner/group root' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+      EOS
+      apply_manifest(pp)
+    end
+    pp = <<-EOS
+      concat_file { '#{basedir}/file':
+        owner => '#{username}',
+        group => '#{groupname}',
+        mode  => '0644',
+      }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/file',
+        content => '1',
+        order   => '01',
+      }
+
+      concat_fragment { '2':
+        target  => '#{basedir}/file',
+        content => '2',
+        order   => '02',
+      }
+    EOS
+
+    it_behaves_like 'successfully_applied', pp
+
+    describe file("#{basedir}/file") do
+      it { should be_file }
+      it { should be_owned_by username }
+      it("should be group", :unless => (fact('osfamily') == 'windows')) { should be_grouped_into groupname }
+      it("should be mode", :unless => (fact('osfamily') == 'AIX' or fact('osfamily') == 'windows')) {
+        should be_mode 644
+      }
+      its(:content) {
+        should match '1'
+        should match '2'
+      }
+    end
+  end
+
+  context 'ensure' do
+    context 'works when set to present with path set' do
+      before(:all) do
+        pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+        EOS
+        apply_manifest(pp)
+      end
+      pp="
+        concat_file { 'file':
+          ensure => present,
+          path   => '#{basedir}/file',
+          mode   => '0644',
+        }
+        concat_fragment { '1':
+          target  => 'file',
+          content => '1',
+          order   => '01',
+        }
+      "
+
+      it_behaves_like 'successfully_applied', pp
+
+      describe file("#{basedir}/file") do
+        it { should be_file }
+        it("should be mode", :unless => (fact('osfamily') == 'AIX' or fact('osfamily') == 'windows')) {
+          should be_mode 644
+        }
+        its(:content) { should match '1' }
+      end
+    end
+    context 'works when set to absent with path set' do
+      before(:all) do
+        pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+        EOS
+        apply_manifest(pp)
+      end
+      pp="
+        concat_file { 'file':
+          ensure => absent,
+          path   => '#{basedir}/file',
+          mode   => '0644',
+        }
+        concat_fragment { '1':
+          target  => 'file',
+          content => '1',
+          order   => '01',
+        }
+      "
+
+      it 'applies the manifest twice with no stderr' do
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{basedir}/file") do
+        it { should_not be_file }
+      end
+    end
+    context 'works when set to present with path that has special characters' do
+      filename = fact('osfamily') == 'windows' ? 'file(1)' : 'file(1:2)'
+
+      before(:all) do
+        pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+        EOS
+        apply_manifest(pp)
+      end
+      pp="
+        concat_file { '#{filename}':
+          ensure => present,
+          path   => '#{basedir}/#{filename}',
+          mode   => '0644',
+        }
+        concat_fragment { '1':
+          target  => '#{filename}',
+          content => '1',
+          order   => '01',
+        }
+      "
+
+      it_behaves_like 'successfully_applied', pp
+
+      describe file("#{basedir}/#{filename}") do
+        it { should be_file }
+        it("should be mode", :unless => (fact('osfamily') == 'AIX' or fact('osfamily') == 'windows')) {
+          should be_mode 644
+        }
+        its(:content) { should match '1' }
+      end
+    end
+    context 'noop properly' do
+      before(:all) do
+        pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+        EOS
+        apply_manifest(pp)
+      end
+      pp="
+        concat_file { 'file':
+          ensure => present,
+          path   => '#{basedir}/file',
+          mode   => '0644',
+          noop   => true,
+        }
+        concat_fragment { '1':
+          target  => 'file',
+          content => '1',
+          order   => '01',
+        }
+      "
+
+      it_behaves_like 'successfully_applied', pp
+
+      describe file("#{basedir}/file") do
+        it { should_not be_file }
+      end
+    end
+  end
+end

--- a/spec/acceptance/native/concurrency_spec.rb
+++ b/spec/acceptance/native/concurrency_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_file with file recursive purge' do
+  basedir = default.tmpdir('concat')
+  context 'should still create concat file' do
+    pp = <<-EOS
+      file { '#{basedir}/bar':
+        ensure => directory,
+        purge  => true,
+        recurse => true,
+      }
+
+      concat_file { "foobar":
+        ensure => 'present',
+        path   => '#{basedir}/bar/foobar',
+      }
+
+      concat_fragment { 'foo':
+        target => 'foobar',
+        content => 'foo',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/bar/foobar") do
+      it { should be_file }
+      its(:content) {
+        should match 'foo'
+      }
+    end
+  end
+end
+

--- a/spec/acceptance/native/fragment_source_spec.rb
+++ b/spec/acceptance/native/fragment_source_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper_acceptance'
+
+case fact('osfamily')
+  when 'AIX'
+    username = 'root'
+    groupname = 'system'
+  when 'Darwin'
+    username = 'root'
+    groupname = 'wheel'
+  when 'windows'
+    username = 'Administrator'
+    groupname = 'Administrators'
+  else
+    username = 'root'
+    groupname = 'root'
+end
+
+describe 'concat_fragment source' do
+  basedir = default.tmpdir('concat')
+  context 'should read file fragments from local system' do
+    pp = <<-EOS
+      file { '#{basedir}/file1':
+        content => "file1 contents\n"
+      }
+      file { '#{basedir}/file2':
+        content => "file2 contents\n"
+      }
+      concat_file { '#{basedir}/foo': }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        source  => '#{basedir}/file1',
+        require => File['#{basedir}/file1'],
+      }
+      concat_fragment { '2':
+        target  => '#{basedir}/foo',
+        content => 'string1 contents',
+      }
+      concat_fragment { '3':
+        target  => '#{basedir}/foo',
+        source  => '#{basedir}/file2',
+        require => File['#{basedir}/file2'],
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/foo") do
+      it { should be_file }
+      its(:content) {
+        should match 'file1 contents'
+        should match 'string1 contents'
+        should match 'file2 contents'
+      }
+    end
+  end # should read file fragments from local system
+
+  context 'should create files containing first match only.' do
+    pp = <<-EOS
+      file { '#{basedir}/file1':
+        content => "file1 contents\n"
+      }
+      file { '#{basedir}/file2':
+        content => "file2 contents\n"
+      }
+      concat_file { '#{basedir}/result_file1':
+        owner   => '#{username}',
+        group   => '#{groupname}',
+        mode    => '0644',
+      }
+      concat_file { '#{basedir}/result_file2':
+        owner   => '#{username}',
+        group   => '#{groupname}',
+        mode    => '0644',
+      }
+      concat_file { '#{basedir}/result_file3':
+        owner   => '#{username}',
+        group   => '#{groupname}',
+        mode    => '0644',
+      }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/result_file1',
+        source  => [ '#{basedir}/file1', '#{basedir}/file2' ],
+        require => [ File['#{basedir}/file1'], File['#{basedir}/file2'] ],
+        order   => '01',
+      }
+      concat_fragment { '2':
+        target  => '#{basedir}/result_file2',
+        source  => [ '#{basedir}/file2', '#{basedir}/file1' ],
+        require => [ File['#{basedir}/file1'], File['#{basedir}/file2'] ],
+        order   => '01',
+      }
+      concat_fragment { '3':
+        target  => '#{basedir}/result_file3',
+        source  => [ '#{basedir}/file1', '#{basedir}/file2' ],
+        require => [ File['#{basedir}/file1'], File['#{basedir}/file2'] ],
+        order   => '01',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+    describe file("#{basedir}/result_file1") do
+      it { should be_file }
+      its(:content) {
+        should match 'file1 contents'
+        should_not match 'file2 contents'
+      }
+    end
+    describe file("#{basedir}/result_file2") do
+      it { should be_file }
+      its(:content) {
+        should match 'file2 contents'
+        should_not match 'file1 contents'
+      }
+    end
+    describe file("#{basedir}/result_file3") do
+      it { should be_file }
+      its(:content) {
+        should match 'file1 contents'
+        should_not match 'file2 contents'
+      }
+    end
+  end
+
+  context 'should fail if no match on source.' do
+    pp = <<-EOS
+      concat_file { '#{basedir}/fail_no_source':
+        owner   => '#{username}',
+        group   => '#{groupname}',
+        mode    => '0644',
+      }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/fail_no_source',
+        source => [ '#{basedir}/nofilehere', '#{basedir}/nothereeither' ],
+        order   => '01',
+      }
+    EOS
+
+    it 'applies the manifest with resource failures' do
+      expect(apply_manifest(pp, :catch_failures => true).stderr).to match(/Failed to generate additional resources using 'eval_generate'/)
+    end
+    describe file("#{basedir}/fail_no_source") do
+      #FIXME: Serverspec::Type::File doesn't support exists? for some reason. so... hack.
+      it { should_not be_directory }
+    end
+  end
+end
+

--- a/spec/acceptance/native/fragments_are_always_replaced_spec.rb
+++ b/spec/acceptance/native/fragments_are_always_replaced_spec.rb
@@ -1,0 +1,139 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_fragment replace' do
+  basedir = default.tmpdir('concat')
+
+  context 'should create fragment files' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+      EOS
+      apply_manifest(pp)
+    end
+
+    pp1 = <<-EOS
+      concat_file { '#{basedir}/foo': }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'caller has replace unset run 1',
+      }
+    EOS
+    pp2 = <<-EOS
+      concat_file { '#{basedir}/foo': }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'caller has replace unset run 2',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp1, :catch_failures => true)
+      apply_manifest(pp1, :catch_changes => true)
+      apply_manifest(pp2, :catch_failures => true)
+      apply_manifest(pp2, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/foo") do
+      it { should be_file }
+      its(:content) {
+        should_not match 'caller has replace unset run 1'
+        should match 'caller has replace unset run 2'
+      }
+    end
+  end # should create fragment files
+
+  context 'should replace its own fragment files when caller has File { replace=>true } set' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+      EOS
+      apply_manifest(pp)
+    end
+
+    pp1 = <<-EOS
+      File { replace=>true }
+      concat_file { '#{basedir}/foo': }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'caller has replace true set run 1',
+      }
+    EOS
+    pp2 = <<-EOS
+      File { replace=>true }
+      concat_file { '#{basedir}/foo': }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'caller has replace true set run 2',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp1, :catch_failures => true)
+      apply_manifest(pp1, :catch_changes => true)
+      apply_manifest(pp2, :catch_failures => true)
+      apply_manifest(pp2, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/foo") do
+      it { should be_file }
+      its(:content) {
+        should_not match 'caller has replace true set run 1'
+        should match 'caller has replace true set run 2'
+      }
+    end
+  end # should replace its own fragment files when caller has File(replace=>true) set
+
+  context 'should replace its own fragment files even when caller has File { replace=>false } set' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory,
+        }
+      EOS
+      apply_manifest(pp)
+    end
+
+    pp1 = <<-EOS
+      File { replace=>false }
+      concat_file { '#{basedir}/foo': }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'caller has replace false set run 1',
+      }
+    EOS
+    pp2 = <<-EOS
+      File { replace=>false }
+      concat_file { '#{basedir}/foo': }
+
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'caller has replace false set run 2',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp1, :catch_failures => true)
+      apply_manifest(pp1, :catch_changes => true)
+      apply_manifest(pp2, :catch_failures => true)
+      apply_manifest(pp2, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/foo") do
+      it { should be_file }
+      its(:content) {
+        should_not match 'caller has replace false set run 1'
+        should match 'caller has replace false set run 2'
+      }
+    end
+  end # should replace its own fragment files even when caller has File(replace=>false) set
+
+end

--- a/spec/acceptance/native/newline_spec.rb
+++ b/spec/acceptance/native/newline_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_file ensure_newline parameter' do
+  basedir = default.tmpdir('concat')
+  context '=> false' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory
+        }
+      EOS
+
+      apply_manifest(pp)
+    end
+    pp = <<-EOS
+      concat_file { '#{basedir}/file':
+        ensure_newline => false,
+      }
+      concat_fragment { '1':
+        target  => '#{basedir}/file',
+        content => '1',
+      }
+      concat_fragment { '2':
+        target  => '#{basedir}/file',
+        content => '2',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/file") do
+      it { should be_file }
+      its(:content) { should match '12' }
+    end
+  end
+
+  context '=> true' do
+    pp = <<-EOS
+      concat_file { '#{basedir}/file':
+        ensure_newline => true,
+      }
+      concat_fragment { '1':
+        target  => '#{basedir}/file',
+        content => '1',
+      }
+      concat_fragment { '2':
+        target  => '#{basedir}/file',
+        content => '2',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/file") do
+      it { should be_file }
+      its(:content) {
+        should match /1\n2\n/
+      }
+    end
+  end
+end

--- a/spec/acceptance/native/order_spec.rb
+++ b/spec/acceptance/native/order_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_file order' do
+  basedir = default.tmpdir('concat')
+
+  context '=> ' do
+    shared_examples 'sortby' do |order_by, match_output|
+      pp = <<-EOS
+      concat_file { '#{basedir}/foo':
+        order => '#{order_by}'
+      }
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'string1',
+        order   => '1',
+      }
+      concat_fragment { '2':
+        target  => '#{basedir}/foo',
+        content => 'string2',
+        order   => '2',
+      }
+      concat_fragment { '10':
+        target  => '#{basedir}/foo',
+        content => 'string10',
+      }
+      EOS
+
+      it 'applies the manifest twice with no stderr' do
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{basedir}/foo") do
+        it { should be_file }
+        its(:content) { should match match_output }
+      end
+    end
+
+    describe 'alpha' do
+      it_behaves_like 'sortby', 'alpha', /string1string10string2/
+    end
+
+    describe 'numeric' do
+      it_behaves_like 'sortby', 'numeric', /string1string2string10/
+    end
+  end
+end # concat order
+
+describe 'concat_fragment order' do
+  basedir = default.tmpdir('concat')
+
+  context '=> reverse order' do
+    shared_examples 'order_by' do |order_by, match_output|
+      pp = <<-EOS
+      concat_file { '#{basedir}/foo':
+          order => '#{order_by}'
+      }
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'string1',
+        order   => '15',
+      }
+      concat_fragment { '2':
+        target  => '#{basedir}/foo',
+        content => 'string2',
+        # default order 10
+      }
+      concat_fragment { '3':
+        target  => '#{basedir}/foo',
+        content => 'string3',
+        order   => '1',
+      }
+      EOS
+
+      it 'applies the manifest twice with no stderr' do
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{basedir}/foo") do
+        it { should be_file }
+        its(:content) { should match match_output }
+      end
+    end
+    describe 'alpha' do
+      it_should_behave_like 'order_by', 'alpha', /string3string2string1/
+    end
+    describe 'numeric' do
+      it_should_behave_like 'order_by', 'numeric', /string3string2string1/
+    end
+  end
+
+  context '=> normal order' do
+    pp = <<-EOS
+      concat_file { '#{basedir}/foo': }
+      concat_fragment { '1':
+        target  => '#{basedir}/foo',
+        content => 'string1',
+        order   => '01',
+      }
+      concat_fragment { '2':
+        target  => '#{basedir}/foo',
+        content => 'string2',
+        order   => '02'
+      }
+      concat_fragment { '3':
+        target  => '#{basedir}/foo',
+        content => 'string3',
+        order   => '03',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/foo") do
+      it { should be_file }
+      its(:content) { should match /string1string2string3/ }
+    end
+  end
+end # concat_fragment order

--- a/spec/acceptance/native/pup-1963_spec.rb
+++ b/spec/acceptance/native/pup-1963_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper_acceptance'
+
+case fact('osfamily')
+  when 'Windows'
+    command = 'cmd.exe /c echo triggered'
+  else
+    command = 'echo triggered'
+end
+
+describe 'concat_file with metaparameters' do
+  describe 'with subscribed resources' do
+    basedir = default.tmpdir('concat')
+
+    context 'should trigger refresh' do
+      pp = <<-EOS
+        concat_file { "foobar":
+          ensure => 'present',
+          path   => '#{basedir}/foobar',
+        }
+
+        concat_fragment { 'foo':
+          target => 'foobar',
+          content => 'foo',
+        }
+
+        exec { 'trigger':
+          path        => $::path,
+          command     => "#{command}",
+          subscribe   => Concat_file['foobar'],
+          refreshonly => true,
+        }
+      EOS
+
+      it 'applies the manifest twice with stdout regex' do
+        expect(apply_manifest(pp, :catch_failures => true).stdout).to match(/Triggered 'refresh'/)
+        expect(apply_manifest(pp, :catch_changes => true).stdout).to_not match(/Triggered 'refresh'/)
+      end
+    end
+  end
+
+  describe 'with resources to notify' do
+    basedir = default.tmpdir('concat')
+    context 'should notify' do
+      pp = <<-EOS
+        exec { 'trigger':
+          path        => $::path,
+          command     => "#{command}",
+          refreshonly => true,
+        }
+
+        concat_file { "foobar":
+          ensure => 'present',
+          path   => '#{basedir}/foobar',
+          notify => Exec['trigger'],
+        }
+
+        concat_fragment { 'foo':
+          target => 'foobar',
+          content => 'foo',
+        }
+      EOS
+
+      it 'applies the manifest twice with stdout regex' do
+        expect(apply_manifest(pp, :catch_failures => true).stdout).to match(/Triggered 'refresh'/)
+        expect(apply_manifest(pp, :catch_changes => true).stdout).to_not match(/Triggered 'refresh'/)
+      end
+    end
+  end
+end

--- a/spec/acceptance/native/quoted_paths_spec.rb
+++ b/spec/acceptance/native/quoted_paths_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_file with quoted paths' do
+  basedir = default.tmpdir('concat')
+
+  before(:all) do
+    pp = <<-EOS
+      file { '#{basedir}':
+        ensure => directory,
+      }
+      file { '#{basedir}/concat test':
+        ensure => directory,
+      }
+    EOS
+    apply_manifest(pp)
+  end
+
+  context 'path with blanks' do
+    pp = <<-EOS
+      concat_file { '#{basedir}/concat test/foo':
+      }
+      concat_fragment { '1':
+        target  => '#{basedir}/concat test/foo',
+        content => 'string1',
+      }
+      concat_fragment { '2':
+        target  => '#{basedir}/concat test/foo',
+        content => 'string2',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/concat test/foo") do
+      it { should be_file }
+      its(:content) { should match /string1string2/ }
+    end
+  end
+end

--- a/spec/acceptance/native/replace_spec.rb
+++ b/spec/acceptance/native/replace_spec.rb
@@ -1,0 +1,261 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_file' do
+  basedir = default.tmpdir('concat')
+  context 'file' do
+    context 'with replace => false' do
+      before(:all) do
+        pp = <<-EOS
+          file { '#{basedir}':
+            ensure => directory,
+          }
+          file { '#{basedir}/file':
+            content => "file exists\n"
+          }
+        EOS
+        apply_manifest(pp)
+      end
+      pp = <<-EOS
+        concat_file { '#{basedir}/file':
+          replace => false,
+        }
+
+        concat_fragment { '1':
+          target  => '#{basedir}/file',
+          content => '1',
+        }
+
+        concat_fragment { '2':
+          target  => '#{basedir}/file',
+          content => '2',
+        }
+      EOS
+
+      it 'applies the manifest twice with no stderr' do
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{basedir}/file") do
+        it { should be_file }
+        its(:content) {
+          should match 'file exists'
+          should_not match '1'
+          should_not match '2'
+        }
+      end
+    end
+
+    context 'with replace => true' do
+      before(:all) do
+        pp = <<-EOS
+          file { '#{basedir}':
+            ensure => directory,
+          }
+          file { '#{basedir}/file':
+            content => "file exists\n"
+          }
+        EOS
+        apply_manifest(pp)
+      end
+      pp = <<-EOS
+        concat_file { '#{basedir}/file':
+          replace => true,
+        }
+
+        concat_fragment { '1':
+          target  => '#{basedir}/file',
+          content => '1',
+        }
+
+        concat_fragment { '2':
+          target  => '#{basedir}/file',
+          content => '2',
+        }
+      EOS
+
+      it 'applies the manifest twice with no stderr' do
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{basedir}/file") do
+        it { should be_file }
+        its(:content) {
+          should_not match 'file exists'
+          should match '1'
+          should match '2'
+        }
+      end
+    end
+  end # file
+
+  context 'symlink', :unless => (fact("osfamily") == "windows") do
+    context 'should not succeed' do
+      # XXX the core puppet file type will replace a symlink with a plain file
+      # when using ensure => present and source => ... but it will not when using
+      # ensure => present and content => ...; this is somewhat confusing behavior
+      before(:all) do
+        pp = <<-EOS
+          file { '#{basedir}':
+            ensure => directory,
+          }
+          file { '#{basedir}/file':
+            ensure => link,
+            target => '#{basedir}/dangling',
+          }
+        EOS
+        apply_manifest(pp)
+      end
+
+      pp = <<-EOS
+        concat_file { '#{basedir}/file':
+          replace => false,
+        }
+
+        concat_fragment { '1':
+          target  => '#{basedir}/file',
+          content => '1',
+        }
+
+        concat_fragment { '2':
+          target  => '#{basedir}/file',
+          content => '2',
+        }
+      EOS
+
+      it 'applies the manifest twice with no stderr' do
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      # XXX specinfra doesn't support be_linked_to on AIX
+      describe file("#{basedir}/file"), :unless => (fact("osfamily") == "AIX" or fact("osfamily") == "windows") do
+        it { should be_linked_to "#{basedir}/dangling" }
+      end
+
+      describe file("#{basedir}/dangling") do
+        # XXX serverspec does not have a matcher for 'exists'
+        it { should_not be_file }
+        it { should_not be_directory }
+      end
+    end
+
+    context 'should succeed' do
+      # XXX the core puppet file type will replace a symlink with a plain file
+      # when using ensure => present and source => ... but it will not when using
+      # ensure => present and content => ...; this is somewhat confusing behavior
+      before(:all) do
+        pp = <<-EOS
+          file { '#{basedir}':
+            ensure => directory,
+          }
+          file { '#{basedir}/file':
+            ensure => link,
+            target => '#{basedir}/dangling',
+          }
+        EOS
+        apply_manifest(pp)
+      end
+
+      pp = <<-EOS
+        concat_file { '#{basedir}/file':
+          replace => true,
+        }
+
+        concat_fragment { '1':
+          target  => '#{basedir}/file',
+          content => '1',
+        }
+
+        concat_fragment { '2':
+          target  => '#{basedir}/file',
+          content => '2',
+        }
+      EOS
+
+      it 'applies the manifest twice with no stderr' do
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{basedir}/file") do
+        it { should be_file }
+        its(:content) {
+          should match '1'
+          should match '2'
+        }
+      end
+    end
+  end # symlink
+
+  context 'directory' do
+    context 'should not succeed' do
+      before(:all) do
+        pp = <<-EOS
+          file { '#{basedir}':
+            ensure => directory,
+          }
+          file { '#{basedir}/file':
+            ensure => directory,
+          }
+        EOS
+        apply_manifest(pp)
+      end
+      pp = <<-EOS
+        concat_file { '#{basedir}/file': }
+
+        concat_fragment { '1':
+          target  => '#{basedir}/file',
+          content => '1',
+        }
+
+        concat_fragment { '2':
+          target  => '#{basedir}/file',
+          content => '2',
+        }
+      EOS
+
+      it 'applies the manifest twice with stderr for changing to file' do
+        expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/change from directory to file failed/)
+        expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/change from directory to file failed/)
+      end
+
+      describe file("#{basedir}/file") do
+        it { should be_directory }
+      end
+    end
+
+    # XXX 
+    # when there are no fragments, and the replace param will only replace
+    # files and symlinks, not directories.  The semantics either need to be
+    # changed, extended, or a new param introduced to control directory
+    # replacement.
+    context 'should succeed', :pending => 'not yet implemented' do
+      pp = <<-EOS
+        concat_file { '#{basedir}/file':
+        }
+
+        concat_fragment { '1':
+          target  => '#{basedir}/file',
+          content => '1',
+        }
+
+        concat_fragment { '2':
+          target  => '#{basedir}/file',
+          content => '2',
+        }
+      EOS
+
+      it 'applies the manifest twice with no stderr' do
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+
+      describe file("#{basedir}/file") do
+        it { should be_file }
+        its(:content) { should match '1' }
+      end
+    end
+  end # directory
+end

--- a/spec/acceptance/native/symbolic_name_spec.rb
+++ b/spec/acceptance/native/symbolic_name_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_file symbolic name' do
+  basedir = default.tmpdir('concat')
+  pp = <<-EOS
+    concat_file { 'not_abs_path':
+      path => '#{basedir}/file',
+    }
+
+    concat_fragment { '1':
+      target  => 'not_abs_path',
+      content => '1',
+      order   => '01',
+    }
+
+    concat_fragment { '2':
+      target  => 'not_abs_path',
+      content => '2',
+      order   => '02',
+    }
+  EOS
+
+  it 'applies the manifest twice with no stderr' do
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+
+  describe file("#{basedir}/file") do
+    it { should be_file }
+    its(:content) {
+      should match '1'
+      should match '2'
+    }
+  end
+end

--- a/spec/acceptance/native/validation_spec.rb
+++ b/spec/acceptance/native/validation_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_file validate_cmd parameter', :unless => (fact('kernel') != 'Linux') do
+  basedir = default.tmpdir('concat')
+  context '=> "/usr/bin/test -e %"' do
+    before(:all) do
+      pp = <<-EOS
+        file { '#{basedir}':
+          ensure => directory
+        }
+      EOS
+
+      apply_manifest(pp)
+    end
+    pp = <<-EOS
+      concat_file { '#{basedir}/file':
+        validate_cmd => '/usr/bin/test -e %',
+      }
+      concat_fragment { 'content':
+        target  => '#{basedir}/file',
+        content => 'content',
+      }
+    EOS
+
+    it 'applies the manifest twice with no stderr' do
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("#{basedir}/file") do
+      it { should be_file }
+      it { should contain 'content' }
+    end
+  end
+end

--- a/spec/acceptance/native/warnings_spec.rb
+++ b/spec/acceptance/native/warnings_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper_acceptance'
+
+describe 'concat_fragment warnings' do
+  basedir = default.tmpdir('concat')
+
+  shared_examples 'has_warning' do |pp, w|
+    it 'applies the manifest twice with a stderr regex' do
+      expect(apply_manifest(pp, :catch_failures => true).stderr).to match(/#{Regexp.escape(w)}/m)
+      expect(apply_manifest(pp, :catch_changes => true).stderr).to match(/#{Regexp.escape(w)}/m)
+    end
+  end
+
+  context 'concat_fragment target not found' do
+    context 'target not found' do
+    pp = <<-EOS
+      concat_file { 'file':
+        path => '#{basedir}/file',
+      }
+      concat_fragment { 'foo':
+        target  => '#{basedir}/bar',
+        content => 'bar',
+      }
+    EOS
+    w = 'not found in the catalog'
+
+    it_behaves_like 'has_warning', pp, w
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,4 +22,3 @@ RSpec.configure do |c|
 
   c.treat_symbols_as_metadata_keys_with_true_values = true
 end
-

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,46 @@
+shared_examples 'Puppet::Parameter::Boolean' do |parameter|
+  [true, :true, 'true', :yes, 'yes'].each do |value|
+    it "accepts #{value} (#{value.class}) as a value" do
+      resource[parameter] = value
+      expect(resource[parameter]).to eq(true)
+    end
+  end
+
+  [false, :false, 'false', :no, 'no'].each do |value|
+    it "accepts #{value} (#{value.class}) as a value" do
+      resource[parameter] = value
+      expect(resource[parameter]).to eq(false)
+    end
+  end
+
+  it 'does not accept "foo" as a value' do
+    expect { resource[parameter] = 'foo' }.to raise_error(%r{Invalid value "foo"})
+  end
+end
+
+shared_examples 'a parameter that accepts only string values' do |parameter|
+  it 'accepts a string value' do
+    resource[parameter] = 'foo'
+    expect(resource[parameter]).to eq('foo')
+  end
+
+  it 'does not accept an array value' do
+    expect { resource[parameter] = %w(foo bar) }.to raise_error(%r{must be a String})
+  end
+
+  it 'does not accept a hash value' do
+    expect { resource[parameter] = { foo: 'bar' } }.to raise_error(%r{must be a String})
+  end
+
+  it 'does not accept an integer value' do
+    expect { resource[parameter] = 9001 }.to raise_error(%r{must be a String})
+  end
+
+  it 'does not accept a boolean true value' do
+    expect { resource[parameter] = true }.to raise_error(%r{must be a String})
+  end
+
+  it 'does not accept a boolean false value' do
+    expect { resource[parameter] = false }.to raise_error(%r{must be a String})
+  end
+end

--- a/spec/unit/type/concat_file_spec.rb
+++ b/spec/unit/type/concat_file_spec.rb
@@ -1,25 +1,5 @@
 require 'spec_helper'
 
-shared_examples 'Puppet::Parameter::Boolean' do |parameter|
-  [true, :true, 'true', :yes, 'yes'].each do |value|
-    it "accepts #{value} (#{value.class}) as a value" do
-      resource[parameter] = value
-      expect(resource[parameter]).to eq(true)
-    end
-  end
-
-  [false, :false, 'false', :no, 'no'].each do |value|
-    it "accepts #{value} (#{value.class}) as a value" do
-      resource[parameter] = value
-      expect(resource[parameter]).to eq(false)
-    end
-  end
-
-  it 'does not accept "foo" as a value' do
-    expect { resource[parameter] = 'foo' }.to raise_error(%r{Invalid value "foo"})
-  end
-end
-
 describe Puppet::Type.type(:concat_file) do
   let(:resource) { described_class.new(name: '/foo/bar') }
 
@@ -39,6 +19,30 @@ describe Puppet::Type.type(:concat_file) do
     end
   end
 
+  describe 'parameter :owner' do
+    subject { described_class.attrclass(:owner) }
+
+    it 'inherits Puppet::Type::File::Owner' do
+      is_expected.to be < Puppet::Type::File::Owner
+    end
+  end
+
+  describe 'parameter :group' do
+    subject { described_class.attrclass(:group) }
+
+    it 'inherits Puppet::Type::File::Group' do
+      is_expected.to be < Puppet::Type::File::Group
+    end
+  end
+
+  describe 'parameter :mode' do
+    subject { described_class.attrclass(:mode) }
+
+    it 'inherits Puppet::Type::File::Mode' do
+      is_expected.to be < Puppet::Type::File::Mode
+    end
+  end
+
   describe 'parameter :order' do
     it 'accepts "alpha" as a value' do
       resource[:order] = 'alpha'
@@ -55,11 +59,52 @@ describe Puppet::Type.type(:concat_file) do
     end
   end
 
+  describe 'parameter :backup' do
+    it 'accepts true (TrueClass) as a value' do
+      resource[:backup] = true
+      expect(resource[:backup]).to eq(true)
+    end
+
+    it 'accepts false (FalseClass) as a value' do
+      resource[:backup] = false
+      expect(resource[:backup]).to eq(false)
+    end
+
+    it 'accepts "foo" as a value' do
+      resource[:backup] = 'foo'
+      expect(resource[:backup]).to eq('foo')
+    end
+  end
+
+  describe 'parameter :selrange' do
+    it_behaves_like 'a parameter that accepts only string values', :selrange
+  end
+
+  describe 'parameter :selrole' do
+    it_behaves_like 'a parameter that accepts only string values', :selrole
+  end
+
+  describe 'parameter :seltype' do
+    it_behaves_like 'a parameter that accepts only string values', :seltype
+  end
+
+  describe 'parameter :seluser' do
+    it_behaves_like 'a parameter that accepts only string values', :seluser
+  end
+
   describe 'parameter :replace' do
     it_behaves_like 'Puppet::Parameter::Boolean', :replace
   end
 
   describe 'parameter :ensure_newline' do
     it_behaves_like 'Puppet::Parameter::Boolean', :ensure_newline
+  end
+
+  describe 'parameter :show_diff' do
+    it_behaves_like 'Puppet::Parameter::Boolean', :show_diff
+  end
+
+  describe 'parameter :selinux_ignore_defaults' do
+    it_behaves_like 'Puppet::Parameter::Boolean', :selinux_ignore_defaults
   end
 end

--- a/spec/unit/type/concat_fragment_spec.rb
+++ b/spec/unit/type/concat_fragment_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:concat_fragment) do
+  let(:resource) do
+    described_class.new(name: 'foo', target: 'bar', content: 'baz')
+  end
+
+  describe 'key attributes' do
+    let(:subject) { described_class.key_attributes }
+
+    it 'contain only :name' do
+      is_expected.to eq([:name])
+    end
+  end
+
+  describe 'parameter :target' do
+    it_behaves_like 'a parameter that accepts only string values', :target
+  end
+
+  describe 'parameter :content' do
+    it_behaves_like 'a parameter that accepts only string values', :content
+  end
+
+  describe 'parameter :source' do
+    it 'accepts a string value' do
+      resource[:source] = 'foo'
+      expect(resource[:source]).to eq('foo')
+    end
+
+    it 'accepts an array value' do
+      resource[:source] = %w(foo bar)
+      expect(resource[:source]).to eq(%w(foo bar))
+    end
+
+    it 'does not accept a hash value' do
+      expect { resource[:source] = { foo: 'bar' } }.to raise_error(%r{must be a String or Array})
+    end
+
+    it 'does not accept an integer value' do
+      expect { resource[:source] = 9001 }.to raise_error(%r{must be a String or Array})
+    end
+
+    it 'does not accept a boolean true value' do
+      expect { resource[:source] = true }.to raise_error(%r{must be a String or Array})
+    end
+
+    it 'does not accept a boolean false value' do
+      expect { resource[:source] = false }.to raise_error(%r{must be a String or Array})
+    end
+  end
+
+  describe 'parameter :order' do
+    it 'accepts a string value' do
+      resource[:order] = 'foo'
+      expect(resource[:order]).to eq('foo')
+    end
+
+    it 'accepts an integer value' do
+      resource[:order] = 9001
+      expect(resource[:order]).to eq(9001)
+    end
+
+    it 'does not accept an array value' do
+      expect { resource[:order] = %w(foo bar) }.to raise_error(%r{is not a string or integer})
+    end
+
+    it 'does not accept a hash value' do
+      expect { resource[:order] = { foo: 'bar' } }.to raise_error(%r{is not a string or integer})
+    end
+
+    it 'does not accept a boolean true value' do
+      expect { resource[:order] = true }.to raise_error(%r{is not a string or integer})
+    end
+
+    it 'does not accept a boolean false value' do
+      expect { resource[:order] = false }.to raise_error(%r{is not a string or integer})
+    end
+
+    it 'does not accept a string with ":" in it/' do
+      expect { resource[:order] = ':foo' }.to raise_error(%r{Order cannot contain})
+    end
+
+    it 'does not accept a string with "\n" in it/' do
+      expect { resource[:order] = "\nfoo" }.to raise_error(%r{Order cannot contain})
+    end
+
+    it 'does not accept a string with "/" in it/' do
+      expect { resource[:order] = '/foo' }.to raise_error(%r{Order cannot contain})
+    end
+  end
+
+  context 'without a value set for :target or :tag' do
+    it 'throws an error' do
+      expect { described_class.new(name: 'foo', content: 'baz') }.to raise_error(%r{No 'target' or 'tag' set})
+    end
+  end
+
+  context 'without a value set for both :content and :source' do
+    it 'throws an error' do
+      expect { described_class.new(name: 'foo', target: 'bar') }.to raise_error(%r{Set either 'source' or 'content'})
+    end
+  end
+
+  context 'with a value set for both :content and :source' do
+    it 'throws an error' do
+      expect do
+        described_class.new(name: 'foo', target: 'bar', content: 'baz', source: 'qux')
+      end.to raise_error(%r{Can't use 'source' and 'content' at the same time})
+    end
+  end
+end


### PR DESCRIPTION
This is a combined PR for the following issues:

[MODULES-4349 - Concat: Fix obsolete Rubocop config](https://tickets.puppetlabs.com/browse/MODULES-4349)
[MODULES-4350 - Concat: Fix path parameter not being a namevar.](https://tickets.puppetlabs.com/browse/MODULES-4350)
[MODULES-4351 - Concat: fix :order parameter accepting arbitrary values in concat_file](https://tickets.puppetlabs.com/browse/MODULES-4351)
[MODULES-4352 - Concat: Restrict parameter :replace to values accepted by file](https://tickets.puppetlabs.com/browse/MODULES-4352)
[MODULES-4359 - Concat: Fix native types so they can be used directly.](https://tickets.puppetlabs.com/browse/MODULES-4359)