### PR TITLE
Invalid tag fix

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -45,7 +45,7 @@ define concat::fragment(
     fail("${resource}['${title}']: Can't use 'source' and 'content' at the same time.")
   }
 
-  $safe_target_name = regsubst($target, '[/:~\n\s\+\*\(\)]', '_', 'GM')
+  $safe_target_name = regsubst($target, '[/:~\n\s\+\*\(\)@]', '_', 'GM')
 
   concat_fragment { $name:
     target  => $target,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,7 +101,7 @@ define concat(
   validate_string($seltype)
   validate_string($seluser)
 
-  $safe_name            = regsubst($name, '[/:~\n\s\+\*\(\)]', '_', 'G')
+  $safe_name            = regsubst($name, '[/:~\n\s\+\*\(\)@]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"
 
   case $warn {

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -93,7 +93,7 @@ describe 'concat', :type => :define do
     end
 
     context 'with special characters in title' do
-      ['foo:bar', 'foo*bar', 'foo(bar)'].each do |title|
+      ['foo:bar', 'foo*bar', 'foo(bar)', 'foo@bar'].each do |title|
         context title do
           it_behaves_like 'concat', title, { :path => '/etc/foo.bar' }
         end


### PR DESCRIPTION
concat doesn't like the @ symbol in file paths.

This fixes this and amends the unit test to check for this.