### PR TITLE
(MODULES-4474) Drop autorequire of fragments in concat_file

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -101,14 +101,6 @@ Puppet::Type.newtype(:concat_file) do
   end
   # End file parameters
 
-  autorequire(:concat_fragment) do
-    catalog.resources.collect do |r|
-      if r.is_a?(Puppet::Type.type(:concat_fragment)) && r[:tag] == self[:tag]
-        r.name
-      end
-    end.compact
-  end
-
   # Autorequire the file we are generating below
   autorequire(:file) do
     [self[:path]]


### PR DESCRIPTION
The concat_file type defines an autorequire of related fragments which
can unnecessarily lead to dependency cycles.

It's not evident why fragments exactly need to be required as the type
seems to work fine without it.

This commit drops the autorequire that collects fragments in
concat_file to prevent these dependency cycles from happening.