### PR TITLE
(MODULES-4264) Update for puppet 4 data types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ supports_windows = true
 #end
 
 group :development do
-  gem 'puppet-strings',                     :require => false
   gem 'puppet-lint',                        :require => false
   gem 'metadata-json-lint',                 :require => false, :platforms => 'ruby'
   gem 'puppet_facts',                       :require => false
@@ -71,7 +70,7 @@ group :system_tests do
   gem 'beaker-module_install_helper',                                            :require => false
   gem 'master_manipulator',                                                      :require => false
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
+  gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ supports_windows = true
 #end
 
 group :development do
+  gem 'puppet-strings',                     :require => false
   gem 'puppet-lint',                        :require => false
   gem 'metadata-json-lint',                 :require => false, :platforms => 'ruby'
   gem 'puppet_facts',                       :require => false
@@ -70,7 +71,7 @@ group :system_tests do
   gem 'beaker-module_install_helper',                                            :require => false
   gem 'master_manipulator',                                                      :require => false
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -1,7 +1,6 @@
 # Creates a concat_fragment in the catalogue
 #
 # @param target The file that these fragments belong to
-# @param ensure
 # @param content If present puts the content into the file
 # @param source If content was not specified, use the source
 # @param order
@@ -9,27 +8,15 @@
 #   anything else using this to influence the order of the content in the file
 #
 define concat::fragment(
-  $target,
-  $ensure  = undef,
-  $content = undef,
-  $source  = undef,
-  $order   = '10',
+  String                  $target,
+  Optional[String]        $content = undef,
+  Variant[String,Integer] $order   = 10,
+  Optional[Variant[String,Array]] $source = undef,
 ) {
-  validate_string($target)
   $resource = 'Concat::Fragment'
 
-  if $ensure != undef {
-    warning('The $ensure parameter to concat::fragment is deprecated and has no effect.')
-  }
 
-  validate_string($content)
-  if !(is_string($source) or is_array($source)) {
-    fail("${resource}['${title}']: 'source' is not a String or an Array.")
-  }
-
-  if !(is_string($order) or is_integer($order)) {
-    fail("${resource}['${title}']: 'order' is not a String or an Integer.")
-  } elsif (is_string($order) and $order =~ /[:\n\/]/) {
+  if (is_string($order) and $order =~ /[:\n\/]/) {
     fail("${resource}['${title}']: 'order' cannot contain '/', ':', or '\n'.")
   }
 

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -1,25 +1,19 @@
-# == Define: concat::fragment
-#
 # Creates a concat_fragment in the catalogue
 #
-# === Options:
-#
-# [*target*]
-#   The file that these fragments belong to
-# [*content*]
-#   If present puts the content into the file
-# [*source*]
-#   If content was not specified, use the source
-# [*order*]
+# @param target The file that these fragments belong to
+# @param ensure
+# @param content If present puts the content into the file
+# @param source If content was not specified, use the source
+# @param order
 #   By default all files gets a 10_ prefix in the directory you can set it to
 #   anything else using this to influence the order of the content in the file
 #
 define concat::fragment(
-    $target,
-    $ensure  = undef,
-    $content = undef,
-    $source  = undef,
-    $order   = '10',
+  $target,
+  $ensure  = undef,
+  $content = undef,
+  $source  = undef,
+  $order   = '10',
 ) {
   validate_string($target)
   $resource = 'Concat::Fragment'

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -8,15 +8,23 @@
 #   anything else using this to influence the order of the content in the file
 #
 define concat::fragment(
-  String                  $target,
-  Optional[String]        $content = undef,
-  Variant[String,Integer] $order   = 10,
-  Optional[Variant[String,Array]] $source = undef,
+  Variant[String, Stdlib::Compat::String]                                         $target,
+                                                                                  $ensure  = undef,
+  Optional[Variant[String, Stdlib::Compat::String]]                               $content = undef,
+  Optional[Variant[String, Stdlib::Compat::String, Array, Stdlib::Compat::Array]] $source  = undef,
+  Variant[String, Stdlib::Compat::String, Integer, Stdlib::Compat::Integer]       $order   = '10',
 ) {
   $resource = 'Concat::Fragment'
 
+  validate_legacy(String, 'validate_string', $target)
+  if $content {
+    validate_legacy(String, 'validate_string', $content)
+  }
+  if $ensure != undef {
+    warning('The $ensure parameter to concat::fragment is deprecated and has no effect.')
+  }
 
-  if (is_string($order) and $order =~ /[:\n\/]/) {
+  if (($order =~ String or $order =~ Stdlib::Compat::String) and $order =~ Pattern[/[:\n\/]/]) {
     fail("${resource}['${title}']: 'order' cannot contain '/', ':', or '\n'.")
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,52 +1,49 @@
-# == Define: concat
-#
 # Sets up so that you can use fragments to build a final config file,
 #
-# === Options:
-#
-# [*ensure*]
+# @param ensure
 #   Present/Absent
-# [*path*]
+# @param path
 #   The path to the final file. Use this in case you want to differentiate
 #   between the name of a resource and the file path.  Note: Use the name you
 #   provided in the target of your fragments.
-# [*owner*]
+# @param owner
 #   Who will own the file
-# [*group*]
+# @param group
 #   Who will own the file
-# [*mode*]
+# @param mode
 #   The mode of the final file
-# [*show_diff*]
+# @param show_diff
 #   Use metaparam for files to show/hide diffs for reporting when using eyaml
 #   secrets.  Defaults to true
-# [*warn*]
+# @param warn
 #   Adds a normal shell style comment top of the file indicating that it is
 #   built by puppet.
 #   Before 2.0.0, this parameter would add a newline at the end of the warn
 #   message. To improve flexibilty, this was removed. Please add it explicitely
 #   if you need it.
-# [*backup*]
+# @param force Deprecated.
+# @param backup
 #   Controls the filebucketing behavior of the final file and see File type
 #   reference for its use.  Defaults to 'puppet'
-# [*replace*]
+# @param replace
 #   Whether to replace a file that already exists on the local system
-# [*order*]
+# @param order
 #   Select whether to order associated fragments by 'alpha' or 'numeric'.
 #   Defaults to 'alpha'.
-# [*ensure_newline*]
+# @param ensure_newline
 #   Specifies whether to ensure there's a new line at the end of each fragment.
 #   Valid options: 'true' and 'false'. Default value: 'false'.
-# [*selinux_ignore_defaults*]
-# [*selrange*]
-# [*selrole*]
-# [*seltype*]
-# [*validate_cmd*]
+# @param selinux_ignore_defaults
+# @param selrange
+# @param selrole
+# @param seltype
+# @param seluser
+# @param validate_cmd
 #   Specifies a validation command to apply to the destination file.
 #   Requires Puppet version 3.5 or newer. Valid options: a string to be passed
 #   to a file resource. Default value: undefined.
 #
-
-define concat(
+define concat (
   $ensure                  = 'present',
   $path                    = $name,
   $owner                   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,6 @@
 #   Before 2.0.0, this parameter would add a newline at the end of the warn
 #   message. To improve flexibilty, this was removed. Please add it explicitely
 #   if you need it.
-# @param force Deprecated.
 # @param backup
 #   Controls the filebucketing behavior of the final file and see File type
 #   reference for its use.  Defaults to 'puppet'
@@ -44,28 +43,24 @@
 #   to a file resource. Default value: undefined.
 #
 define concat (
-  $ensure                  = 'present',
-  $path                    = $name,
-  $owner                   = undef,
-  $group                   = undef,
-  $mode                    = '0644',
-  $warn                    = false,
-  $force                   = undef,
-  $show_diff               = true,
-  $backup                  = 'puppet',
-  $replace                 = true,
-  $order                   = 'alpha',
-  $ensure_newline          = false,
-  $validate_cmd            = undef,
-  $selinux_ignore_defaults = undef,
-  $selrange                = undef,
-  $selrole                 = undef,
-  $seltype                 = undef,
-  $seluser                 = undef
+  Enum['present','absent']          $ensure                  = 'present',
+  String                            $path                    = $name,
+  Optional[Variant[String,Integer]] $owner                   = undef,
+  Optional[Variant[String,Integer]] $group                   = undef,
+  String                            $mode                    = '0644',
+  Variant[Boolean,String]           $warn                    = false,
+  Boolean                           $show_diff               = true,
+  Variant[Boolean,String]           $backup                  = 'puppet',
+  Boolean                           $replace                 = true,
+  Enum['alpha','numeric']           $order                   = 'alpha',
+  Boolean                           $ensure_newline          = false,
+  Optional[String]                  $validate_cmd            = undef,
+  Optional[Boolean]                 $selinux_ignore_defaults = undef,
+  Optional[String]                  $selrange                = undef,
+  Optional[String]                  $selrole                 = undef,
+  Optional[String]                  $seltype                 = undef,
+  Optional[String]                  $seluser                 = undef
 ) {
-  validate_re($ensure, '^present$|^absent$')
-  validate_absolute_path($path)
-  validate_string($mode)
   if ! (is_string($owner) or is_integer($owner)) {
     fail("\$owner must be a string or integer, got ${owner}")
   }
@@ -75,28 +70,18 @@ define concat (
   if ! (is_string($warn) or $warn == true or $warn == false) {
     fail('$warn is not a string or boolean')
   }
-  validate_bool($show_diff)
   if ! is_bool($backup) and ! is_string($backup) {
-    fail('$backup must be string or bool!')
-  }
-  validate_bool($replace)
-  validate_re($order, '^alpha$|^numeric$')
-  validate_bool($ensure_newline)
-
-  if $validate_cmd and ! is_string($validate_cmd) {
-    fail('$validate_cmd must be a string')
+    fail('$backup must be string or boolean')
   }
 
-  if $force != undef {
-    warning('The $force parameter to concat is deprecated and has no effect.')
+  if $name !~ Stdlib::AbsolutePath {
+    if $path !~ Stdlib::AbsolutePath {
+      fail('If $name is not a path, $path must be an absolute path')
+    }
   }
-  if $selinux_ignore_defaults {
-    validate_bool($selinux_ignore_defaults)
+  if $path and $path !~ Stdlib::AbsolutePath {
+    fail('If $name is not a path, $path must be an absolute path')
   }
-  validate_string($selrange)
-  validate_string($selrole)
-  validate_string($seltype)
-  validate_string($seluser)
 
   $safe_name            = regsubst($name, '[/:~\n\s\+\*\(\)@]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,45 +42,41 @@
 #   Requires Puppet version 3.5 or newer. Valid options: a string to be passed
 #   to a file resource. Default value: undefined.
 #
-define concat (
-  Enum['present','absent']          $ensure                  = 'present',
-  String                            $path                    = $name,
-  Optional[Variant[String,Integer]] $owner                   = undef,
-  Optional[Variant[String,Integer]] $group                   = undef,
-  String                            $mode                    = '0644',
-  Variant[Boolean,String]           $warn                    = false,
-  Boolean                           $show_diff               = true,
-  Variant[Boolean,String]           $backup                  = 'puppet',
-  Boolean                           $replace                 = true,
-  Enum['alpha','numeric']           $order                   = 'alpha',
-  Boolean                           $ensure_newline          = false,
-  Optional[String]                  $validate_cmd            = undef,
-  Optional[Boolean]                 $selinux_ignore_defaults = undef,
-  Optional[String]                  $selrange                = undef,
-  Optional[String]                  $selrole                 = undef,
-  Optional[String]                  $seltype                 = undef,
-  Optional[String]                  $seluser                 = undef
+define concat(
+  Enum['present', 'absent']                                                           $ensure                  = 'present',
+  Stdlib::Absolutepath                                                                $path                    = $name,
+  Optional[Variant[String, Stdlib::Compat::String, Integer, Stdlib::Compat::Integer]] $owner                   = undef,
+  Optional[Variant[String, Stdlib::Compat::String, Integer, Stdlib::Compat::Integer]] $group                   = undef,
+  Variant[String, Stdlib::Compat::String]                                             $mode                    = '0644',
+  Variant[Boolean, String, Stdlib::Compat::String]                                    $warn                    = false,
+                                                                                      $force                   = undef,
+  Boolean                                                                             $show_diff               = true,
+  Variant[Boolean, String, Stdlib::Compat::String]                                    $backup                  = 'puppet',
+  Boolean                                                                             $replace                 = true,
+  Enum['alpha','numeric']                                                             $order                   = 'alpha',
+  Boolean                                                                             $ensure_newline          = false,
+  Optional[Variant[String, Stdlib::Compat::String]]                                   $validate_cmd            = undef,
+  Optional[Boolean]                                                                   $selinux_ignore_defaults = undef,
+  Optional[Variant[String, Stdlib::Compat::String]]                                   $selrange                = undef,
+  Optional[Variant[String, Stdlib::Compat::String]]                                   $selrole                 = undef,
+  Optional[Variant[String, Stdlib::Compat::String]]                                   $seltype                 = undef,
+  Optional[Variant[String, Stdlib::Compat::String]]                                   $seluser                 = undef,
 ) {
-  if ! (is_string($owner) or is_integer($owner)) {
-    fail("\$owner must be a string or integer, got ${owner}")
-  }
-  if ! (is_string($group) or is_integer($group)) {
-    fail("\$group must be a string or integer, got ${group}")
-  }
-  if ! (is_string($warn) or $warn == true or $warn == false) {
-    fail('$warn is not a string or boolean')
-  }
-  if ! is_bool($backup) and ! is_string($backup) {
-    fail('$backup must be string or boolean')
-  }
+  if $owner =~ Integer or $owner =~ Stdlib::Compat::Integer { validate_legacy(Integer, 'validate_integer', $owner) }
+  if $owner =~ String or $owner =~ Stdlib::Compat::String { validate_legacy(String, 'validate_string', $owner) }
+  if $group =~ Integer or $group =~ Stdlib::Compat::Integer { validate_legacy(Integer, 'validate_integer', $group) }
+  if $group =~ String or $group =~ Stdlib::Compat::String { validate_legacy(String, 'validate_string', $group) }
+  validate_legacy(String, 'validate_string', $mode)
+  if $warn !~ Boolean { validate_legacy(String, 'validate_string', $warn) }
+  if $backup !~ Boolean { validate_legacy(String, 'validate_string', $backup) }
+  validate_legacy(String, 'validate_string', $validate_cmd)
+  validate_legacy(String, 'validate_string', $selrange)
+  validate_legacy(String, 'validate_string', $selrole)
+  validate_legacy(String, 'validate_string', $seltype)
+  validate_legacy(String, 'validate_string', $seluser)
 
-  if $name !~ Stdlib::AbsolutePath {
-    if $path !~ Stdlib::AbsolutePath {
-      fail('If $name is not a path, $path must be an absolute path')
-    }
-  }
-  if $path and $path !~ Stdlib::AbsolutePath {
-    fail('If $name is not a path, $path must be an absolute path')
+  if $force != undef {
+    warning('The $force parameter to concat is deprecated and has no effect.')
   }
 
   $safe_name            = regsubst($name, '[/:~\n\s\+\*\(\)@]', '_', 'G')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-concat",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "author": "Puppet Labs",
   "summary": "Construct files from multiple fragments.",
   "license": "Apache-2.0",
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-concat",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.12.0 < 5.0.0"}
   ],
   "data_provider": null,
   "operatingsystem_support": [
@@ -103,7 +103,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-concat",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.12.0 < 5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 5.0.0"}
   ],
   "data_provider": null,
   "operatingsystem_support": [
@@ -103,7 +103,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ]
 }

--- a/spec/acceptance/warnings_spec.rb
+++ b/spec/acceptance/warnings_spec.rb
@@ -10,38 +10,6 @@ describe 'warnings' do
     end
   end
 
-  context 'concat force parameter deprecation' do
-    pp = <<-EOS
-      concat { '#{basedir}/file':
-        force => false,
-      }
-      concat::fragment { 'foo':
-        target  => '#{basedir}/file',
-        content => 'bar',
-      }
-    EOS
-    w = 'The $force parameter to concat is deprecated and has no effect.'
-
-    it_behaves_like 'has_warning', pp, w
-  end
-
-  context 'concat::fragment ensure parameter deprecation' do
-    context 'target file exists' do
-    pp = <<-EOS
-      concat { '#{basedir}/file':
-      }
-      concat::fragment { 'foo':
-        target  => '#{basedir}/file',
-        ensure  => false,
-        content => 'bar',
-      }
-    EOS
-    w = 'The $ensure parameter to concat::fragment is deprecated and has no effect.'
-
-    it_behaves_like 'has_warning', pp, w
-    end
-  end
-
   context 'concat::fragment target not found' do
     context 'target not found' do
     pp = <<-EOS

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -45,15 +45,6 @@ describe 'concat::fragment', :type => :define do
         }
       end
     end
-
-    context 'false' do
-      let(:title) { 'motd_header' }
-      let(:params) {{ :target => false }}
-
-      it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
-      end
-    end
   end # target =>
 
   context 'content =>' do
@@ -65,15 +56,6 @@ describe 'concat::fragment', :type => :define do
         }
       end
     end
-
-    context 'false' do
-      let(:title) { 'motd_header' }
-      let(:params) {{ :content => false, :target => '/etc/motd' }}
-
-      it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
-      end
-    end
   end # content =>
 
   context 'source =>' do
@@ -83,15 +65,6 @@ describe 'concat::fragment', :type => :define do
           :source => source,
           :target => '/etc/motd',
         }
-      end
-    end
-
-    context 'false' do
-      let(:title) { 'motd_header' }
-      let(:params) {{ :source => false, :target => '/etc/motd' }}
-
-      it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a String or an Array/)
       end
     end
   end # source =>
@@ -111,7 +84,7 @@ describe 'concat::fragment', :type => :define do
       let(:params) {{ :order => false, :target => '/etc/motd' }}
 
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a String or an Integer/)
+        expect { catalogue }.to raise_error(Puppet::Error, /expects a value of type String or Integer/)
       end
     end
 

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -45,6 +45,15 @@ describe 'concat::fragment', :type => :define do
         }
       end
     end
+
+    context 'false' do
+      let(:title) { 'motd_header' }
+      let(:params) {{ :target => false }}
+
+      it 'should fail' do
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'target' expects a String value/)
+      end
+    end
   end # target =>
 
   context 'content =>' do
@@ -54,6 +63,15 @@ describe 'concat::fragment', :type => :define do
           :content => content,
           :target  => '/etc/motd',
         }
+      end
+    end
+
+    context 'false' do
+      let(:title) { 'motd_header' }
+      let(:params) {{ :content => false, :target => '/etc/motd' }}
+
+      it 'should fail' do
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'content' expects a String value/)
       end
     end
   end # content =>
@@ -67,6 +85,15 @@ describe 'concat::fragment', :type => :define do
         }
       end
     end
+
+    context 'false' do
+       let(:title) { 'motd_header' }
+       let(:params) {{ :source => false, :target => '/etc/motd' }}
+
+       it 'should fail' do
+         expect { catalogue }.to raise_error(Puppet::Error, /parameter 'source' expects a value of type String or Array/)
+       end
+     end
   end # source =>
 
   context 'order =>' do

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -11,9 +11,6 @@ describe 'concat::fragment', :type => :define do
       :order   => 10,
     }.merge(params)
 
-    id               = 'root'
-    gid              = 'root'
-
     let(:title) { title }
     let(:params) { params }
     let(:pre_condition) do
@@ -91,7 +88,7 @@ describe 'concat::fragment', :type => :define do
        let(:params) {{ :source => false, :target => '/etc/motd' }}
 
        it 'should fail' do
-         expect { catalogue }.to raise_error(Puppet::Error, /parameter 'source' expects a value of type String or Array/)
+         expect { catalogue }.to raise_error(Puppet::Error, /parameter 'source' expects a value of type String, Array/)
        end
      end
   end # source =>
@@ -111,7 +108,7 @@ describe 'concat::fragment', :type => :define do
       let(:params) {{ :order => false, :target => '/etc/motd' }}
 
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /expects a value of type String or Integer/)
+        expect { catalogue }.to raise_error(Puppet::Error, /expects a value of type String, Integer, Pattern, or Array/)
       end
     end
 

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -147,7 +147,7 @@ describe 'concat', :type => :define do
 
   context 'owner =>' do
     ['apenney',1000,'1001'].each do |owner|
-      context "#{owner}" do
+      context owner do
         it_behaves_like 'concat', '/etc/foo.bar', { :owner => owner }
       end
     end
@@ -163,7 +163,7 @@ describe 'concat', :type => :define do
 
   context 'group =>' do
     ['apenney',1000,'1001'].each do |group|
-      context "#{group}" do
+      context group do
         it_behaves_like 'concat', '/etc/foo.bar', { :group => group }
       end
     end

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'concat', :type => :define do
 
-  shared_examples 'concat' do |title, params, id| 
+  shared_examples 'concat' do |title, params, id|
     params = {} if params.nil?
     id = 'root' if id.nil?
 
@@ -78,7 +78,7 @@ describe 'concat', :type => :define do
         context title do
           let(:title) { title }
           it 'should fail' do
-            expect { catalogue }.to raise_error(Puppet::Error, /is not an absolute path/)
+            expect { catalogue }.to raise_error(Puppet::Error, /\$name is not a path, \$path must be an absolute path/)
           end
         end
       end
@@ -116,7 +116,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :ensure => 'invalid' }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /#{Regexp.escape('does not match "^present$|^absent$"')}/)
+        expect { catalogue }.to raise_error(Puppet::Error, /expects a match for Enum\['absent', 'present'\]/)
       end
     end
   end # ensure =>
@@ -126,49 +126,53 @@ describe 'concat', :type => :define do
       it_behaves_like 'concat', '/etc/foo.bar', { :path => '/foo' }
     end
 
-    ['./foo', 'foo', 'foo/bar', false].each do |path|
+    context 'false' do
+      let(:title) { '/etc/foo.bar' }
+      let(:params) {{ :path => false }}
+      it 'should fail' do
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'path' expects a String value/)
+      end
+    end
+
+    ['./foo', 'foo', 'foo/bar'].each do |path|
       context path do
         let(:title) { '/etc/foo.bar' }
         let(:params) {{ :path => path }}
         it 'should fail' do
-          expect { catalogue }.to raise_error(Puppet::Error, /is not an absolute path/)
+          expect { catalogue }.to raise_error(Puppet::Error, /\$name is not a path, \$path must be an absolute path/)
         end
       end
     end
   end # path =>
 
   context 'owner =>' do
-    context 'apenney' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :owner => 'apenny' }
-    end
-
-    context '1000' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :owner => 1000 }
+    ['apenney',1000,'1001'].each do |owner|
+      context "#{owner}" do
+        it_behaves_like 'concat', '/etc/foo.bar', { :owner => owner }
+      end
     end
 
     context 'false' do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :owner => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /\$owner must be a string or integer/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'owner' expects a value of type String or Integer/)
       end
     end
   end # owner =>
 
   context 'group =>' do
-    context 'apenney' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :group => 'apenny' }
-    end
-
-    context '1000' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :group => 1000 }
+    ['apenney',1000,'1001'].each do |group|
+      context "#{group}" do
+        it_behaves_like 'concat', '/etc/foo.bar', { :group => group }
+      end
     end
 
     context 'false' do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :group => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /\$group must be a string or integer/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'group' expects a value of type String or Integer/)
       end
     end
   end # group =>
@@ -182,7 +186,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :mode => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'mode' expects a String value/)
       end
     end
   end # mode =>
@@ -210,7 +214,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :warn => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a string or boolean/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'warn' expects a value of type Boolean or String/)
       end
     end
   end # warn =>
@@ -226,29 +230,23 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :show_diff => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a boolean/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'show_diff' expects a Boolean value/)
       end
     end
   end # show_diff =>
 
   context 'backup =>' do
-    context 'reverse' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :backup => 'reverse' }
-    end
-
-    context 'false' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :backup => false }
-    end
-
-    context 'true' do
-      it_behaves_like 'concat', '/etc/foo.bar', { :backup => true }
+    ['reverse',false,true].each do |backup|
+      context "#{backup}" do
+        it_behaves_like 'concat', '/etc/foo.bar', { :backup => backup }
+      end
     end
 
     context 'true' do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :backup => [] }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /backup must be string or bool/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'backup' expects a value of type Boolean or String/)
       end
     end
   end # backup =>
@@ -264,7 +262,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :replace => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a boolean/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'replace' expects a Boolean value/)
       end
     end
   end # replace =>
@@ -280,7 +278,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :order => 'invalid' }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /#{Regexp.escape('does not match "^alpha$|^numeric$"')}/)
+        expect { catalogue }.to raise_error(Puppet::Error, /expects a match for Enum\['alpha', 'numeric'\]/)
       end
     end
   end # order =>
@@ -296,24 +294,22 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :ensure_newline => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a boolean/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'ensure_newline' expects a Boolean value/)
       end
     end
   end # ensure_newline =>
 
   context 'validate_cmd =>' do
-    if Puppet::Util::Package::versioncmp(Puppet::version, '3.5.0') > 0
-      context '/usr/bin/test -e %' do
-        it_behaves_like 'concat', '/etc/foo.bar', { :validate_cmd => '/usr/bin/test -e %' }
-      end
+    context '/usr/bin/test -e %' do
+      it_behaves_like 'concat', '/etc/foo.bar', { :validate_cmd => '/usr/bin/test -e %' }
+    end
 
-      [ 1234, true ].each do |cmd|
-        context cmd do
-          let(:title) { '/etc/foo.bar' }
-          let(:params) {{ :validate_cmd => cmd }}
-          it 'should fail' do
-            expect { catalogue }.to raise_error(Puppet::Error, /\$validate_cmd must be a string/)
-          end
+    [ 1234, true ].each do |cmd|
+      context cmd do
+        let(:title) { '/etc/foo.bar' }
+        let(:params) {{ :validate_cmd => cmd }}
+        it 'should fail' do
+          expect { catalogue }.to raise_error(Puppet::Error, /parameter 'validate_cmd' expects a String value/)
         end
       end
     end
@@ -332,7 +328,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :selinux_ignore_defaults => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a boolean/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'selinux_ignore_defaults' expects a Boolean value/)
       end
     end
   end # selinux_ignore_defaults =>
@@ -354,7 +350,7 @@ describe 'concat', :type => :define do
         let(:title) { '/etc/foo.bar' }
         let(:params) {{ p => false }}
         it 'should fail' do
-          expect { catalogue }.to raise_error(Puppet::Error, /is not a string/)
+          expect { catalogue }.to raise_error(Puppet::Error, /parameter '#{p}' expects a String value/)
         end
       end
     end # #{p} =>

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -18,9 +18,6 @@ describe 'concat', :type => :define do
       :replace        => true,
     }.merge(params)
 
-    concat_name          = 'fragments.concat.out'
-    default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"
-
     file_defaults = {
       :backup  => p[:backup],
     }
@@ -78,7 +75,7 @@ describe 'concat', :type => :define do
         context title do
           let(:title) { title }
           it 'should fail' do
-            expect { catalogue }.to raise_error(Puppet::Error, /\$name is not a path, \$path must be an absolute path/)
+            expect { catalogue }.to raise_error(Puppet::Error, /Stdlib::Unixpath/)
           end
         end
       end
@@ -130,7 +127,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :path => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'path' expects a String value/)
+        expect { catalogue }.to raise_error(Puppet::Error, /Stdlib::Unixpath/)
       end
     end
 
@@ -139,7 +136,7 @@ describe 'concat', :type => :define do
         let(:title) { '/etc/foo.bar' }
         let(:params) {{ :path => path }}
         it 'should fail' do
-          expect { catalogue }.to raise_error(Puppet::Error, /\$name is not a path, \$path must be an absolute path/)
+          expect { catalogue }.to raise_error(Puppet::Error, /Stdlib::Unixpath/)
         end
       end
     end
@@ -156,7 +153,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :owner => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'owner' expects a value of type String or Integer/)
+        expect { catalogue }.to raise_error(Puppet::Error, /expects a value of type String, Integer, Pattern, or Array/)
       end
     end
   end # owner =>
@@ -172,7 +169,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :group => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'group' expects a value of type String or Integer/)
+        expect { catalogue }.to raise_error(Puppet::Error, /expects a value of type String, Integer, Pattern, or Array/)
       end
     end
   end # group =>
@@ -328,7 +325,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :selinux_ignore_defaults => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'selinux_ignore_defaults' expects a Boolean value/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'selinux_ignore_defaults' expects a value of type Undef or Boolean/)
       end
     end
   end # selinux_ignore_defaults =>


### PR DESCRIPTION
The data types for validation are using the puppet 4 types with
validate_legacy to check for any legacy types that will be removed on
the next release. This should be a backwards-compatible change except
that it uses puppet 4's data types.