### PR TITLE
[concat] Puppet::Parameter::Boolean yields error on puppet 3.2.

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -70,7 +70,7 @@ Puppet::Type.newtype(:concat_file) do
     defaultto 'puppet'
   end
 
-  newparam(:replace, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newparam(:replace, :boolean => true) do
     desc "Whether to replace a file that already exists on the local system."
     defaultto :true
   end
@@ -79,7 +79,7 @@ Puppet::Type.newtype(:concat_file) do
     desc "Validates file."
   end
 
-  newparam(:ensure_newline, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newparam(:ensure_newline, :boolean => true) do
     desc "Whether to ensure there is a newline after each fragment."
     defaultto :false
   end

--- a/spec/unit/type/concat_file_spec.rb
+++ b/spec/unit/type/concat_file_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 shared_examples 'Puppet::Parameter::Boolean' do |parameter|
     it "accepts true (#{true.class}) as a value" do
-    resource[parameter] = value
+    resource[parameter] = true
     expect(resource[parameter]).to eq(:true)
   end
 
   it "accepts false (#{false.class}) as a value" do
-    resource[parameter] = value
+    resource[parameter] = true
     expect(resource[parameter]).to eq(:false)
   end
 end

--- a/spec/unit/type/concat_file_spec.rb
+++ b/spec/unit/type/concat_file_spec.rb
@@ -1,22 +1,14 @@
 require 'spec_helper'
 
 shared_examples 'Puppet::Parameter::Boolean' do |parameter|
-  [true, :true, 'true', :yes, 'yes'].each do |value|
-    it "accepts #{value} (#{value.class}) as a value" do
-      resource[parameter] = value
-      expect(resource[parameter]).to eq(true)
-    end
+    it "accepts true (#{true.class}) as a value" do
+    resource[parameter] = value
+    expect(resource[parameter]).to eq(:true)
   end
 
-  [false, :false, 'false', :no, 'no'].each do |value|
-    it "accepts #{value} (#{value.class}) as a value" do
-      resource[parameter] = value
-      expect(resource[parameter]).to eq(false)
-    end
-  end
-
-  it 'does not accept "foo" as a value' do
-    expect { resource[parameter] = 'foo' }.to raise_error(%r{Invalid value "foo"})
+  it "accepts false (#{false.class}) as a value" do
+    resource[parameter] = value
+    expect(resource[parameter]).to eq(:false)
   end
 end
 


### PR DESCRIPTION
So while running my spec tests on my module, I encountered an issue when testing for puppet 3.2 (all other supported versions seemed to be fine).

The error reported was: 
```
Puppet::Error:                                                                                                                                                                  
       Could not autoload puppet/type/concat_file: uninitialized constant Puppet::Parameter::Boolean on (redacted)
```

Since puppet >=3.0 is supported, I believe this is unexpected behavior and should somehow be fixed. I was able to get around the problem by applying the same fix the guys in the CPAN module used (https://github.com/meltwater/puppet-cpan/commit/59a1acfe5e560687da923dbf345bad829d407d35).

This PR is likely not complete as it doesn't address the spec tests define in spec/unit/type/concat_file_spec.rb, as I'm not sure what that entails. I would've actually preferred to open an issue instead of a PR, but you guys don't have issues enabled :)

Anyways, don't hesitate to let me know if you need anything else from me. 

Thanks!