### PR TITLE
(maint) fix spec test errors

### DIFF
--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -108,7 +108,7 @@ describe 'concat::fragment', :type => :define do
       let(:params) {{ :order => false, :target => '/etc/motd' }}
 
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /expects a value of type String, Integer, Pattern, or Array/)
+        expect { catalogue }.to raise_error(Puppet::Error, /Evaluation Error.*expects.*Boolean.*/)
       end
     end
 

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -153,7 +153,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :owner => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /expects a value of type String, Integer, Pattern, or Array/)
+        expect { catalogue }.to raise_error(Puppet::Error, /Evaluation Error.*expects.*Boolean.*/)
       end
     end
   end # owner =>
@@ -169,7 +169,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :group => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /expects a value of type String, Integer, Pattern, or Array/)
+        expect { catalogue }.to raise_error(Puppet::Error, /Evaluation Error.*expects.*Boolean.*/)
       end
     end
   end # group =>
@@ -325,7 +325,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :selinux_ignore_defaults => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'selinux_ignore_defaults' expects a value of type Undef or Boolean/)
+        expect { catalogue }.to raise_error(Puppet::Error, /Evaluation Error.*expects.*Boolean.*/)
       end
     end
   end # selinux_ignore_defaults =>


### PR DESCRIPTION
A couple of examples were expecting the wrong error messages so this was just a matter of correcting those for Puppet 4. Then I found that depending on minor version, Puppet 4 uses different error messages, so these regex matches are pretty liberal but I think they do the trick.