### PR TITLE
(maint) update spec_helper_acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -11,16 +11,16 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
       get_deps = <<-EOS
       package{'wget':}
       exec{'download-stdlib':
-        command => "wget -P /root/ https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.5.1.tar.gz --no-check-certificate",
+        command => "wget -P /root/ https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.13.1.tar.gz --no-check-certificate",
         path    => ['/opt/csw/bin/','/usr/bin/']
       }
       EOS
       apply_manifest_on(host, get_deps)
       # have to use force otherwise it checks ssl cert even though it is a local file
-      on host, puppet('module install /root/puppetlabs-stdlib-4.5.1.tar.gz --force --ignore-dependencies'), {:acceptable_exit_codes => [0, 1]}
+      on host, puppet('module install /root/puppetlabs-stdlib-4.13.1.tar.gz --force --ignore-dependencies'), {:acceptable_exit_codes => [0, 1]}
     elsif host['platform'] =~ /windows/i
-      on host, 'curl -k -o c:/puppetlabs-stdlib-4.5.1.tar.gz https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.5.1.tar.gz'
-      on host, puppet('module install c:/puppetlabs-stdlib-4.5.1.tar.gz --force --ignore-dependencies'), {:acceptable_exit_codes => [0, 1]}
+      on host, 'curl -k -o c:/puppetlabs-stdlib-4.13.1.tar.gz https://forgeapi.puppetlabs.com/v3/files/puppetlabs-stdlib-4.13.1.tar.gz'
+      on host, puppet('module install c:/puppetlabs-stdlib-4.13.1.tar.gz --force --ignore-dependencies'), {:acceptable_exit_codes => [0, 1]}
     else
       on host, puppet('module install puppetlabs-stdlib'), {:acceptable_exit_codes => [0, 1]}
     end


### PR DESCRIPTION
acceptance tests were installing stdlib 4.5.1 for SLES which is a super
old version of stdlib. the old version didn't contain many of the
resource types required for puppet 4 types. this updates to 4.13.1 in
spec_helper_acceptance to fix the issue.