### PR TITLE
(FM-6154 MODULES-4739) remove deprecation warnings and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ All the parameters listed below are optional.
 
 Data type: Boolean, String.
 
-Specifies whether (and how) to back up the destination file before overwriting it. Your value gets passed on to Puppet's [native `file` resource](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) for execution. Valid options: 'true', 'false', or a string representing either a target filebucket or a filename extension beginning with ".". 
+Specifies whether (and how) to back up the destination file before overwriting it. Your value gets passed on to Puppet's [native `file` resource](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) for execution. Valid options: `true`, `false`, or a string representing either a target filebucket or a filename extension beginning with ".".
 
 Default value: 'puppet'.
 
 ##### `backup_fragments`
 
-Specifies whether to backup concat fragments using the backup setting of the target concat file. Valid options: 'true' and 'false'. Default value: 'false'.
+Specifies whether to backup concat fragments using the backup setting of the target concat file. Valid options: `true` and `false`. Default value: `false`.
 
 ##### `ensure`
 
@@ -154,9 +154,9 @@ Default value: 'present'.
 
 Data type: Boolean.
 
-Specifies whether to add a line break at the end of each fragment that doesn't already end in one. Valid options: 'true' and 'false'. 
+Specifies whether to add a line break at the end of each fragment that doesn't already end in one. Valid options: `true` and `false`.
 
-Default value: 'false'.
+Default value: `false`.
 
 ##### `group`
 
@@ -208,17 +208,17 @@ Default value: `namevar`
 
 Data type: Boolean.
 
-Specifies whether to overwrite the destination file if it already exists. Valid options: 'true' and 'false'. 
+Specifies whether to overwrite the destination file if it already exists. Valid options: `true` and `false`.
 
-Default value: 'true'.
+Default value: `true`.
 
 ##### `show_diff`
 
 Data type: Boolean.
 
-Specifies whether to set the show_diff parameter for the file resource. Useful for hiding secrets stored in hiera from insecure reporting methods. Valid options: 'true'.
+Specifies whether to set the show_diff parameter for the file resource. Useful for hiding secrets stored in hiera from insecure reporting methods. Valid options: `true`.
 
-Default value: 'true'.
+Default value: `true`.
 
 ##### `validate_cmd`
 
@@ -234,11 +234,11 @@ Default value: `undef`.
 
 Data type: Boolean, String.
 
-Specifies whether to add a header message at the top of the destination file. Valid options: the booleans 'true' and 'false', or a string to serve as the header. 
+Specifies whether to add a header message at the top of the destination file. Valid options: the booleans `true` and `false`, or a string to serve as the header.
 
-If you set 'warn' to 'true', `concat` adds the following line with an `order` of `0`:
+If you set 'warn' to `true`, `concat` adds the following line with an `order` of `0`:
 
-Default value: 'false'.
+Default value: `false`.
 
 ~~~
 # This file is managed by Puppet. DO NOT EDIT.
@@ -322,7 +322,7 @@ Specifies the destination file of the fragment. Valid options: a string containi
 
 Data type: String, Boolean. 
 
-Specifies whether (and how) to back up the destination file before overwriting it. Your value gets passed on to Puppet's [native `file` resource](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) for execution. Valid options: 'true', 'false', or a string representing either a target filebucket or a filename extension beginning with ".". 
+Specifies whether (and how) to back up the destination file before overwriting it. Your value gets passed on to Puppet's [native `file` resource](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) for execution. Valid options: `true`, `false`, or a string representing either a target filebucket or a filename extension beginning with ".".
 
 Default value: 'puppet'.
 
@@ -338,9 +338,9 @@ Default value: 'present'.
 
 Data type: Boolean.
 
-Specifies whether to add a line break at the end of each fragment that doesn't already end in one. Valid options: 'true' and 'false'. 
+Specifies whether to add a line break at the end of each fragment that doesn't already end in one. Valid options: `true` and `false`.
 
-Default value: 'false'.
+Default value: `false`.
 
 ##### `group`
 
@@ -388,15 +388,19 @@ Default value: `namevar`.
 
 Data type: Boolean.
 
-Specifies whether to overwrite the destination file if it already exists. Valid options: 'true' and 'false'. 
+Specifies whether to overwrite the destination file if it already exists. Valid options: `true` and `false`.
 
-Default value: 'true'.
+Default value: `true`.
 
-#### `tag`
+##### `tag`
+
+Data type: String.
 
 *Required.* Specifies a unique tag reference to collect all concat_fragments with the same tag.
 
 ##### `validate_cmd`
+
+Data typeL String
 
 Specifies a validation command to apply to the destination file. Requires Puppet version 3.5 or newer. Valid options: a string to be passed to a file resource. 
 
@@ -406,11 +410,15 @@ Default value: `undef`.
 
 ##### `content`
 
+Data type: String.
+
 Supplies the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string. 
 
 Default value: `undef`.
 
 ##### `order`
+
+Data type: String, Integer.
 
 Reorders your fragments within the destination file. Fragments that share the same order number are ordered by name. Valid options: a string (recommended) or an integer. 
 
@@ -418,15 +426,21 @@ Default value: '10'.
 
 ##### `source`
 
+Data type: String.
+
 Specifies a file to read into the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string or an array, containing one or more Puppet URLs. 
 
 Default value: `undef`.
 
 ##### `tag`
 
+Data type: String.
+
 *Required.* Specifies a unique tag to be used by concat_file to reference and collect content.
 
 ##### `target`
+
+Data type: String.
 
 *Required.* Specifies the destination file of the fragment. Valid options: a string containing the path or title of the parent `concat_file` resource.
 
@@ -443,7 +457,7 @@ Parameters removed from `concat::fragment`:
 
 The `concat::setup` class has also been removed.
 
-Prior to concat version 2.0.0, if you set the `warn` parameter to a string value of 'true', 'false', 'yes', 'no', 'on', or 'off', the module translated the string to the corresponding boolean value. In concat version 2.0.0 and newer, the `warn_header` parameter treats those values the same as other strings and uses them as the content of your header message. To avoid that, pass the 'true' and 'false' values as booleans instead of strings.
+Prior to concat version 2.0.0, if you set the `warn` parameter to a string value of `true`, `false`, 'yes', 'no', 'on', or 'off', the module translated the string to the corresponding boolean value. In concat version 2.0.0 and newer, the `warn_header` parameter treats those values the same as other strings and uses them as the content of your header message. To avoid that, pass the `true` and `false` values as booleans instead of strings.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ All the parameters listed below are optional.
 
 ##### `backup`
 
-Specifies whether (and how) to back up the destination file before overwriting it. Your value gets passed on to Puppet's [native `file` resource](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) for execution. Valid options: 'true', 'false', or a string representing either a target filebucket or a filename extension beginning with ".". Default value: 'puppet'.
+Data type: Boolean, String.
+
+Specifies whether (and how) to back up the destination file before overwriting it. Your value gets passed on to Puppet's [native `file` resource](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) for execution. Valid options: 'true', 'false', or a string representing either a target filebucket or a filename extension beginning with ".". 
+
+Default value: 'puppet'.
 
 ##### `backup_fragments`
 
@@ -140,55 +144,101 @@ Specifies whether to backup concat fragments using the backup setting of the tar
 
 ##### `ensure`
 
-Specifies whether the destination file should exist. Setting to 'absent' tells Puppet to delete the destination file if it exists, and negates the effect of any other parameters. Valid options: 'present' and 'absent'. Default value: 'present'.
+Data type: String.
+
+Specifies whether the destination file should exist. Setting to 'absent' tells Puppet to delete the destination file if it exists, and negates the effect of any other parameters. Valid options: 'present' and 'absent'. 
+
+Default value: 'present'.
 
 ##### `ensure_newline`
 
-Specifies whether to add a line break at the end of each fragment that doesn't already end in one. Valid options: 'true' and 'false'. Default value: 'false'.
+Data type: Boolean.
 
-##### `force`
+Specifies whether to add a line break at the end of each fragment that doesn't already end in one. Valid options: 'true' and 'false'. 
 
-Deprecated as of concat v2.0.0. Has no effect.
+Default value: 'false'.
 
 ##### `group`
 
-Specifies a permissions group for the destination file. Valid options: a string containing a group name. Default value: undefined.
+Optional.
+
+Data type: String, Integer.
+
+Specifies a permissions group for the destination file. Valid options: a string containing a group name. 
+
+Default value: `undef`.
 
 ##### `mode`
 
-Specifies the permissions mode of the destination file. Valid options: a string containing a permission mode value in octal notation. Default value: '0644'.
+Data type: String.
+
+Specifies the permissions mode of the destination file. Valid options: a string containing a permission mode value in octal notation. 
+
+Default value: '0644'.
 
 ##### `order`
 
-Specifies a method for sorting your fragments by name within the destination file. Valid options: 'alpha' (e.g., '1, 10, 2') or 'numeric' (e.g., '1, 2, 10'). Default value: 'alpha'.
+Data type: String.
+
+Specifies a method for sorting your fragments by name within the destination file. Valid options: 'alpha' (e.g., '1, 10, 2') or 'numeric' (e.g., '1, 2, 10'). 
 
 You can override this setting for individual fragments by adjusting the `order` parameter in their `concat::fragment` declarations.
 
+Default value: 'alpha'.
+
 ##### `owner`
 
-Specifies the owner of the destination file. Valid options: a string containing a username. Default value: undefined.
+Optional.
+
+Data type: String, Integer.
+ 
+Specifies the owner of the destination file. Valid options: a string containing a username. 
+
+Default value: `undef`.
 
 ##### `path`
 
-Specifies a destination file for the combined fragments. Valid options: a string containing an absolute path. Default value: the title of your declared resource.
+Data type: Stdlib::AbsolutePath.
+
+Specifies a destination file for the combined fragments. Valid options: a string containing an absolute path. 
+
+Default value: `namevar`
 
 ##### `replace`
 
-Specifies whether to overwrite the destination file if it already exists. Valid options: 'true' and 'false'. Default value: 'true'.
+Data type: Boolean.
+
+Specifies whether to overwrite the destination file if it already exists. Valid options: 'true' and 'false'. 
+
+Default value: 'true'.
 
 ##### `show_diff`
 
+Data type: Boolean.
+
 Specifies whether to set the show_diff parameter for the file resource. Useful for hiding secrets stored in hiera from insecure reporting methods. Valid options: 'true'.
+
+Default value: 'true'.
 
 ##### `validate_cmd`
 
-Specifies a validation command to apply to the destination file. Requires Puppet version 3.5 or newer. Valid options: a string to be passed to a file resource. Default value: undefined.
+Optional.
+
+Data type: String.
+
+Specifies a validation command to apply to the destination file. Requires Puppet version 3.5 or newer. Valid options: a string to be passed to a file resource. 
+
+Default value: `undef`.
 
 ##### `warn`
 
-Specifies whether to add a header message at the top of the destination file. Valid options: the booleans 'true' and 'false', or a string to serve as the header. Default value: 'false'.
+Data type: Boolean, String.
+
+Specifies whether to add a header message at the top of the destination file. Valid options: the booleans 'true' and 'false', or a string to serve as the header. 
 
 If you set 'warn' to 'true', `concat` adds the following line with an `order` of `0`:
+
+Default value: 'false'.
 
 ~~~
 # This file is managed by Puppet. DO NOT EDIT.
@@ -235,86 +285,142 @@ Except where noted, all the below parameters are optional.
 
 ##### `content`
 
-Supplies the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string. Default value: undef.
+Data type: String.
 
-##### `ensure`
+Supplies the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string. 
 
-Deprecated as of concat v2.0.0. Has no effect.
+Default value: `undef`.
 
 ##### `order`
 
-Reorders your fragments within the destination file. Fragments that share the same order number are ordered by name. Valid options: a string (recommended) or an integer. Default value: '10'.
+Data type: String, Integer.
+
+Reorders your fragments within the destination file. Fragments that share the same order number are ordered by name. Valid options: a string (recommended) or an integer. 
+
+Default value: '10'.
 
 ##### `source`
 
-Specifies a file to read into the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string or an array, containing one or more Puppet URLs. Default value: undefined.
+Data type: String, Array.
+
+Specifies a file to read into the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string or an array, containing one or more Puppet URLs. 
+
+Default value: `undef`.
 
 ##### `target`
 
-*Required.* Specifies the destination file of the fragment. Valid options: a string containing the path or title of the parent `concat` resource.
+*Required.*
+
+Data type: String.
+
+Specifies the destination file of the fragment. Valid options: a string containing the path or title of the parent `concat` resource.
 
 
 #### Type: `concat_file`
 
 ##### `backup`
 
-Specifies whether (and how) to back up the destination file before overwriting it. Your value gets passed on to Puppet's [native `file` resource](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) for execution. Valid options: 'true', 'false', or a string representing either a target filebucket or a filename extension beginning with ".". Default value: 'puppet'.
+Data type: String, Boolean. 
+
+Specifies whether (and how) to back up the destination file before overwriting it. Your value gets passed on to Puppet's [native `file` resource](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) for execution. Valid options: 'true', 'false', or a string representing either a target filebucket or a filename extension beginning with ".". 
+
+Default value: 'puppet'.
 
 ##### `ensure`
 
-Specifies whether the destination file should exist. Setting to 'absent' tells Puppet to delete the destination file if it exists, and negates the effect of any other parameters. Valid options: 'present' and 'absent'. Default value: 'present'.
+Data type: String.
+
+Specifies whether the destination file should exist. Setting to 'absent' tells Puppet to delete the destination file if it exists, and negates the effect of any other parameters. Valid options: 'present' and 'absent'. 
+
+Default value: 'present'.
 
 ##### `ensure_newline`
 
-Specifies whether to add a line break at the end of each fragment that doesn't already end in one. Valid options: 'true' and 'false'. Default value: 'false'.
+Data type: Boolean.
+
+Specifies whether to add a line break at the end of each fragment that doesn't already end in one. Valid options: 'true' and 'false'. 
+
+Default value: 'false'.
 
 ##### `group`
 
-Specifies a permissions group for the destination file. Valid options: a string containing a group name. Default value: undefined.
+Data type: String, Integer.
+
+Specifies a permissions group for the destination file. Valid options: a string containing a group name. 
+
+Default value: `undef`.
 
 ##### `mode`
 
-Specifies the permissions mode of the destination file. Valid options: a string containing a permission mode value in octal notation. Default value: '0644'.
+Data type: String.
+
+Specifies the permissions mode of the destination file. Valid options: a string containing a permission mode value in octal notation. 
+
+Default value: '0644'.
 
 ##### `order`
 
-Specifies a method for sorting your fragments by name within the destination file. Valid options: 'alpha' (e.g., '1, 10, 2') or 'numeric' (e.g., '1, 2, 10'). Default value: 'numeric'.
+Data type: String.
+
+Specifies a method for sorting your fragments by name within the destination file. Valid options: 'alpha' (e.g., '1, 10, 2') or 'numeric' (e.g., '1, 2, 10'). 
 
 You can override this setting for individual fragments by adjusting the `order` parameter in their `concat::fragment` declarations.
 
+Default value: 'numeric'.
+
 ##### `owner`
 
-Specifies the owner of the destination file. Valid options: a string containing a username. Default value: undefined.
+Data type: String, Integer.
+
+Specifies the owner of the destination file. Valid options: a string containing a username. 
+
+Default value: `undef`.
 
 ##### `path`
 
+Data type: String.
+
 Specifies a destination file for the combined fragments. Valid options: a string containing an absolute path. Default value: the title of your declared resource.
+
+Default value: `namevar`.
 
 ##### `replace`
 
-Specifies whether to overwrite the destination file if it already exists. Valid options: 'true' and 'false'. Default value: 'true'.
+Data type: Boolean.
+
+Specifies whether to overwrite the destination file if it already exists. Valid options: 'true' and 'false'. 
+
+Default value: 'true'.
 
 #### `tag`
 
 *Required.* Specifies a unique tag reference to collect all concat_fragments with the same tag.
 
-#####` validate_cmd`
+##### `validate_cmd`
 
-Specifies a validation command to apply to the destination file. Requires Puppet version 3.5 or newer. Valid options: a string to be passed to a file resource. Default value: undefined.
+Specifies a validation command to apply to the destination file. Requires Puppet version 3.5 or newer. Valid options: a string to be passed to a file resource. 
+
+Default value: `undef`.
 
 #### Type: `concat_fragment`
 
 ##### `content`
 
-Supplies the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string. Default value: undef.
+Supplies the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string. 
+
+Default value: `undef`.
 
 ##### `order`
 
-Reorders your fragments within the destination file. Fragments that share the same order number are ordered by name. Valid options: a string (recommended) or an integer. Default value: '10'.
+Reorders your fragments within the destination file. Fragments that share the same order number are ordered by name. Valid options: a string (recommended) or an integer. 
+
+Default value: '10'.
 
 ##### `source`
 
-Specifies a file to read into the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string or an array, containing one or more Puppet URLs. Default value: undefined.
+Specifies a file to read into the content of the fragment. **Note**: You must supply either a `content` parameter or a `source` parameter. Valid options: a string or an array, containing one or more Puppet URLs. 
+
+Default value: `undef`.
 
 ##### `tag`
 

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -8,23 +8,14 @@
 #   anything else using this to influence the order of the content in the file
 #
 define concat::fragment(
-  Variant[String, Stdlib::Compat::String]                                         $target,
-                                                                                  $ensure  = undef,
-  Optional[Variant[String, Stdlib::Compat::String]]                               $content = undef,
-  Optional[Variant[String, Stdlib::Compat::String, Array, Stdlib::Compat::Array]] $source  = undef,
-  Variant[String, Stdlib::Compat::String, Integer, Stdlib::Compat::Integer]       $order   = '10',
+  String                             $target,
+  Optional[String]                   $content = undef,
+  Optional[Variant[String, Array]]   $source  = undef,
+  Variant[String, Integer]           $order   = '10',
 ) {
   $resource = 'Concat::Fragment'
 
-  validate_legacy(String, 'validate_string', $target)
-  if $content {
-    validate_legacy(String, 'validate_string', $content)
-  }
-  if $ensure != undef {
-    warning('The $ensure parameter to concat::fragment is deprecated and has no effect.')
-  }
-
-  if (($order =~ String or $order =~ Stdlib::Compat::String) and $order =~ Pattern[/[:\n\/]/]) {
+  if (is_string($order) and $order =~ /[:\n\/]/) {
     fail("${resource}['${title}']: 'order' cannot contain '/', ':', or '\n'.")
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,40 +43,44 @@
 #   to a file resource. Default value: undefined.
 #
 define concat(
-  Enum['present', 'absent']                                                           $ensure                  = 'present',
-  Stdlib::Absolutepath                                                                $path                    = $name,
-  Optional[Variant[String, Stdlib::Compat::String, Integer, Stdlib::Compat::Integer]] $owner                   = undef,
-  Optional[Variant[String, Stdlib::Compat::String, Integer, Stdlib::Compat::Integer]] $group                   = undef,
-  Variant[String, Stdlib::Compat::String]                                             $mode                    = '0644',
-  Variant[Boolean, String, Stdlib::Compat::String]                                    $warn                    = false,
-                                                                                      $force                   = undef,
-  Boolean                                                                             $show_diff               = true,
-  Variant[Boolean, String, Stdlib::Compat::String]                                    $backup                  = 'puppet',
-  Boolean                                                                             $replace                 = true,
-  Enum['alpha','numeric']                                                             $order                   = 'alpha',
-  Boolean                                                                             $ensure_newline          = false,
-  Optional[Variant[String, Stdlib::Compat::String]]                                   $validate_cmd            = undef,
-  Optional[Boolean]                                                                   $selinux_ignore_defaults = undef,
-  Optional[Variant[String, Stdlib::Compat::String]]                                   $selrange                = undef,
-  Optional[Variant[String, Stdlib::Compat::String]]                                   $selrole                 = undef,
-  Optional[Variant[String, Stdlib::Compat::String]]                                   $seltype                 = undef,
-  Optional[Variant[String, Stdlib::Compat::String]]                                   $seluser                 = undef,
+  Enum['present', 'absent']          $ensure                  = 'present',
+  Stdlib::Absolutepath               $path                    = $name,
+  Optional[Variant[String, Integer]] $owner                   = undef,
+  Optional[Variant[String, Integer]] $group                   = undef,
+  String                             $mode                    = '0644',
+  Variant[Boolean, String]           $warn                    = false,
+  Boolean                            $show_diff               = true,
+  Variant[Boolean, String]           $backup                  = 'puppet',
+  Boolean                            $replace                 = true,
+  Enum['alpha','numeric']            $order                   = 'alpha',
+  Boolean                            $ensure_newline          = false,
+  Optional[String]                   $validate_cmd            = undef,
+  Optional[Boolean]                  $selinux_ignore_defaults = undef,
+  Optional[String]                   $selrange                = undef,
+  Optional[String]                   $selrole                 = undef,
+  Optional[String]                   $seltype                 = undef,
+  Optional[String]                   $seluser                 = undef,
 ) {
-  if $owner =~ Integer or $owner =~ Stdlib::Compat::Integer { validate_legacy(Integer, 'validate_integer', $owner) }
-  if $owner =~ String or $owner =~ Stdlib::Compat::String { validate_legacy(String, 'validate_string', $owner) }
-  if $group =~ Integer or $group =~ Stdlib::Compat::Integer { validate_legacy(Integer, 'validate_integer', $group) }
-  if $group =~ String or $group =~ Stdlib::Compat::String { validate_legacy(String, 'validate_string', $group) }
-  validate_legacy(String, 'validate_string', $mode)
-  if $warn !~ Boolean { validate_legacy(String, 'validate_string', $warn) }
-  if $backup !~ Boolean { validate_legacy(String, 'validate_string', $backup) }
-  validate_legacy(String, 'validate_string', $validate_cmd)
-  validate_legacy(String, 'validate_string', $selrange)
-  validate_legacy(String, 'validate_string', $selrole)
-  validate_legacy(String, 'validate_string', $seltype)
-  validate_legacy(String, 'validate_string', $seluser)
+  if ! (is_string($owner) or is_integer($owner)) {
+    fail("\$owner must be a string or integer, got ${owner}")
+  }
+  if ! (is_string($group) or is_integer($group)) {
+    fail("\$group must be a string or integer, got ${group}")
+  }
+  if ! (is_string($warn) or $warn == true or $warn == false) {
+    fail('$warn is not a string or boolean')
+  }
+  if ! is_bool($backup) and ! is_string($backup) {
+    fail('$backup must be string or boolean')
+  }
 
-  if $force != undef {
-    warning('The $force parameter to concat is deprecated and has no effect.')
+  if $name !~ Stdlib::AbsolutePath {
+    if $path !~ Stdlib::AbsolutePath {
+      fail('If $name is not a path, $path must be an absolute path')
+    }
+  }
+  if $path and $path !~ Stdlib::AbsolutePath {
+    fail('If $name is not a path, $path must be an absolute path')
   }
 
   $safe_name            = regsubst($name, '[/:~\n\s\+\*\(\)@]', '_', 'G')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,27 +61,6 @@ define concat(
   Optional[String]                   $seltype                 = undef,
   Optional[String]                   $seluser                 = undef,
 ) {
-  if ! (is_string($owner) or is_integer($owner)) {
-    fail("\$owner must be a string or integer, got ${owner}")
-  }
-  if ! (is_string($group) or is_integer($group)) {
-    fail("\$group must be a string or integer, got ${group}")
-  }
-  if ! (is_string($warn) or $warn == true or $warn == false) {
-    fail('$warn is not a string or boolean')
-  }
-  if ! is_bool($backup) and ! is_string($backup) {
-    fail('$backup must be string or boolean')
-  }
-
-  if $name !~ Stdlib::AbsolutePath {
-    if $path !~ Stdlib::AbsolutePath {
-      fail('If $name is not a path, $path must be an absolute path')
-    }
-  }
-  if $path and $path !~ Stdlib::AbsolutePath {
-    fail('If $name is not a path, $path must be an absolute path')
-  }
 
   $safe_name            = regsubst($name, '[/:~\n\s\+\*\(\)@]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"

--- a/spec/unit/defines/concat_fragment_spec.rb
+++ b/spec/unit/defines/concat_fragment_spec.rb
@@ -48,7 +48,7 @@ describe 'concat::fragment', :type => :define do
       let(:params) {{ :target => false }}
 
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'target' expects a String value/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'target' expects a .*String.*/)
       end
     end
   end # target =>
@@ -68,7 +68,7 @@ describe 'concat::fragment', :type => :define do
       let(:params) {{ :content => false, :target => '/etc/motd' }}
 
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'content' expects a String value/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'content' expects a .*String.*/ )
       end
     end
   end # content =>
@@ -88,7 +88,7 @@ describe 'concat::fragment', :type => :define do
        let(:params) {{ :source => false, :target => '/etc/motd' }}
 
        it 'should fail' do
-         expect { catalogue }.to raise_error(Puppet::Error, /parameter 'source' expects a value of type String, Array/)
+         expect { catalogue }.to raise_error(Puppet::Error, /parameter 'source' expects a .*String.*Array.*/)
        end
      end
   end # source =>

--- a/spec/unit/defines/concat_spec.rb
+++ b/spec/unit/defines/concat_spec.rb
@@ -153,7 +153,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :owner => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /Evaluation Error.*expects.*Boolean.*/)
+        expect { catalogue }.to raise_error(Puppet::Error, /Evaluation Error.*expects.*String.*Boolean.*/)
       end
     end
   end # owner =>
@@ -169,7 +169,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :group => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /Evaluation Error.*expects.*Boolean.*/)
+        expect { catalogue }.to raise_error(Puppet::Error, /Evaluation Error.*expects.*String.*Boolean.*/)
       end
     end
   end # group =>
@@ -183,7 +183,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :mode => false }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'mode' expects a String value/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'mode' expects .*String.*/)
       end
     end
   end # mode =>
@@ -211,7 +211,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :warn => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'warn' expects a value of type Boolean or String/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'warn' expects .*Boolean.*String.*/)
       end
     end
   end # warn =>
@@ -227,7 +227,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :show_diff => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'show_diff' expects a Boolean value/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'show_diff' expects .*Boolean.*/)
       end
     end
   end # show_diff =>
@@ -243,7 +243,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :backup => [] }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'backup' expects a value of type Boolean or String/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'backup' expects .*Boolean.*String.*/)
       end
     end
   end # backup =>
@@ -259,7 +259,7 @@ describe 'concat', :type => :define do
       let(:title) { '/etc/foo.bar' }
       let(:params) {{ :replace => 123 }}
       it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'replace' expects a Boolean value/)
+        expect { catalogue }.to raise_error(Puppet::Error, /parameter 'replace' expects .*Boolean.*/)
       end
     end
   end # replace =>
@@ -306,7 +306,7 @@ describe 'concat', :type => :define do
         let(:title) { '/etc/foo.bar' }
         let(:params) {{ :validate_cmd => cmd }}
         it 'should fail' do
-          expect { catalogue }.to raise_error(Puppet::Error, /parameter 'validate_cmd' expects a String value/)
+          expect { catalogue }.to raise_error(Puppet::Error, /parameter 'validate_cmd' expects.*String.*/)
         end
       end
     end
@@ -347,7 +347,7 @@ describe 'concat', :type => :define do
         let(:title) { '/etc/foo.bar' }
         let(:params) {{ p => false }}
         it 'should fail' do
-          expect { catalogue }.to raise_error(Puppet::Error, /parameter '#{p}' expects a String value/)
+          expect { catalogue }.to raise_error(Puppet::Error, /parameter '#{p}' expects.*String.*/)
         end
       end
     end # #{p} =>


### PR DESCRIPTION
As part of the 4.0.0 release of this module, the deprecation warnings for the new data types, as well as the compatibility types, have been removed from all manifests. Also, the README is updated for Puppet 4 types.