### PR TITLE
(MODULES-5085) Ensure that replace test handles qoutes in change message

### DIFF
--- a/spec/acceptance/replace_spec.rb
+++ b/spec/acceptance/replace_spec.rb
@@ -217,8 +217,8 @@ describe 'replacement of' do
       EOS
 
       it 'applies the manifest twice with stderr for changing to file' do
-        expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/change from directory to file failed/)
-        expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/change from directory to file failed/)
+        expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/change from '?directory'? to '?file'? failed/)
+        expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/change from '?directory'? to '?file'? failed/)
       end
 
       describe file("#{basedir}/file") do


### PR DESCRIPTION
This commit adds optional quotes to the regexps of the replace_spec that
tests expected change messages.