### PR TITLE
Release prep for concat 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Supported Releases 4.0.1
+### Summary
+
+This is a small release that updates regex in a test due to changes made in Puppet.
+
+#### Bugfixes
+
+- (MODULES-5085) Ensure that replace test handles qoutes in change message
+
 ## Supported Releases 3.0.0 & 4.0.0
 ### Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-concat",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Puppet Labs",
   "summary": "Construct files from multiple fragments.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This includes updates to the changelog and the metadata.json version in
preparation for a release.