### PR TITLE
(MODULES-5122) Verify Puppet >= v3.5 before adding 'validate_cmd' param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -194,8 +194,8 @@ define concat(
       backup  => $backup,
     }
 
-    # Only newer versions of puppet 3.x support the validate_cmd parameter
-    if $validate_cmd {
+    # Only versions of puppet >= 3.5 support the validate_cmd parameter
+    if $validate_cmd and (versioncmp($::puppetversion, '3.5') >= 0) {
       File[$name] {
         validate_cmd => $validate_cmd,
       }


### PR DESCRIPTION
This commit makes fixes a catalog compilation failure ("Invalid parameter validate_cmd") in systems running Puppet versions <3.5 using concat 1.2.5.
init.pp does not check if the puppet version is >=3.5 and adds 'validate_cmd' parameter which breaks the catalog compilation. 'validate_cmd' parameter should only be added if puppet version >= 3.5.

Also added more meaningful comment to the if statement where the parameter is added.