### PR TITLE
Added format attribute to type and handling on generating content

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,14 @@ Specify what data type to merge the fragments as. Valid options: 'plain', 'yaml'
 
 Default value: `plain`.
 
+##### `force`
+
+Data type: Boolean
+
+Specifies whether to merge data structures, keeping the values with higher order. Valid options: `true` and `false`.
+
+Default value: `false`.
+
 #### Type: `concat_fragment`
 
 ##### `content`

--- a/README.md
+++ b/README.md
@@ -396,11 +396,19 @@ Data type: String.
 
 ##### `validate_cmd`
 
-Data typeL String
+Data type: String
 
 Specifies a validation command to apply to the destination file. Requires Puppet version 3.5 or newer. Valid options: a string to be passed to a file resource. 
 
 Default value: `undef`.
+
+##### `format`
+
+Data type: String
+
+Specify what data type to merge the fragments as. Valid options: 'plain', 'yaml', 'json', 'json-pretty'.
+
+Default value: `plain`.
 
 #### Type: `concat_fragment`
 

--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -92,6 +92,12 @@ Puppet::Type.newtype(:concat_file) do
     defaultto :plain
   end
 
+  newparam(:force, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "Forcibly merge duplicate keys keeping values of the highest order."
+
+    defaultto :false
+  end
+
   # Inherit File parameters
   newparam(:selinux_ignore_defaults) do
   end
@@ -186,6 +192,17 @@ Puppet::Type.newtype(:concat_file) do
       elsif v1.is_a?(Array) and v2.is_a?(Array)
         (v1+v2).uniq
       else
+        # Fail if there are duplicate keys without force
+        unless v1 == v2
+          unless self[:force]
+            err_message = [
+              "Duplicate key '#{k}' found with values '#{v1}' and #{v2}'.",
+              'Use \'force\' attribute to merge keys.',
+            ]
+            fail(err_message.join(' '))
+          end
+          Puppet.debug("Key '#{k}': replacing '#{v2}' with '#{v1}'.")
+        end
         v1
       end
     end

--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -84,6 +84,14 @@ Puppet::Type.newtype(:concat_file) do
     defaultto :false
   end
 
+  newparam(:format) do
+    desc "What data type to merge the fragments as."
+
+    newvalues(:plain, :yaml, :json, :'json-pretty')
+
+    defaultto :plain
+  end
+
   # Inherit File parameters
   newparam(:selinux_ignore_defaults) do
   end
@@ -137,9 +145,50 @@ Puppet::Type.newtype(:concat_file) do
       end
     end
 
-    @generated_content = sorted.map { |cf| cf[1] }.join
+    case self[:format]
+    when :plain
+      @generated_content = sorted.map { |cf| cf[1] }.join
+    when :yaml
+      content_array = sorted.map do |cf|
+        YAML.load(cf[1])
+      end
+      content_hash = content_array.reduce({}) do |memo, current|
+        nested_merge(memo, current)
+      end
+      @generated_content = content_hash.to_yaml
+    when :json
+      content_array = sorted.map do |cf|
+        JSON.parse(cf[1])
+      end
+      content_hash = content_array.reduce({}) do |memo, current|
+        nested_merge(memo, current)
+      end
+      # Convert Hash
+      @generated_content = content_hash.to_json
+    when :'json-pretty'
+      content_array = sorted.map do |cf|
+        JSON.parse(cf[1])
+      end
+      content_hash = content_array.reduce({}) do |memo, current|
+        nested_merge(memo, current)
+      end
+      @generated_content = JSON.pretty_generate(content_hash)
+    end
 
     @generated_content
+  end
+
+  def nested_merge(hash1, hash2)
+    # Deep-merge Hashes; higher order value is kept
+    hash1.merge(hash2) do |k, v1, v2|
+      if v1.is_a?(Hash) and v2.is_a?(Hash)
+        nested_merge(v1, v2)
+      elsif v1.is_a?(Array) and v2.is_a?(Array)
+        (v1+v2).uniq
+      else
+        v1
+      end
+    end
   end
 
   def fragment_content(r)


### PR DESCRIPTION
Adding a `format` attribute which allows you to treat `concat_fragments` as data instead of just plain-text.  This allows you to merge and present fragments as `json`, `json-pretty`, or `yaml`.

Noticed there weren't spec tests with dummy content, so I haven't added any spec tests.  Put some examples [here](https://gist.github.com/WhatsARanjit/936bd17415c43db58570ad62170f916c).

[MODULES-5124](https://tickets.puppetlabs.com/browse/MODULES-5124)