### PR TITLE
is_string is deprecated. Please use puppet language

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -15,7 +15,7 @@ define concat::fragment(
 ) {
   $resource = 'Concat::Fragment'
 
-  if (is_string($order) and $order =~ /[:\n\/]/) {
+  if ($order =~ String and $order =~ /[:\n\/]/) {
     fail("${resource}['${title}']: 'order' cannot contain '/', ':', or '\n'.")
   }
 


### PR DESCRIPTION
Warning: This method is deprecated, please use match expressions with Stdlib::Compat::String instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions. at ["concat/manifests/fragment.pp", 18]:
==> myserver.local:    (stdlib/lib/puppet/functions/deprecation.rb:25:in `deprecation')