### PR TITLE
Don't call join on a potential string when failing

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -183,7 +183,7 @@ Puppet::Type.newtype(:concat_file) do
           break
         end
       end
-      self.fail "Could not retrieve source(s) #{r[:source].join(", ")}" unless @source
+      self.fail "Could not retrieve source(s) #{[r[:source]].flatten.compact.join(", ")}" unless @source
       tmp = Puppet::FileServing::Content.indirection.find(@source)
       fragment_content = tmp.content unless tmp.nil?
     end


### PR DESCRIPTION
When `fail()`ing in case a fragment source is not found don't call `join` directly on `r[:source]` because it might very well be a string, not an array. Wrap `r[:source]` in a (compacted, flattened) array before calling `join`.

This avoids confusing error messages like `Failed to generate additional resources using 'eval_generate': undefined method 'join' for "foo":String` when a fragment source cannot be found. See also https://tickets.puppetlabs.com/browse/MODULES-4140.