### PR TITLE
Move tests to follow the rpsec-puppet pattern

### DIFF
--- a/spec/defines/concat_fragment_spec.rb
+++ b/spec/defines/concat_fragment_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'concat::fragment', :type => :define do
+describe 'concat::fragment' do
 
   shared_examples 'fragment' do |title, params|
     params = {} if params.nil?
@@ -95,7 +95,7 @@ describe 'concat::fragment', :type => :define do
 
   context 'order =>' do
     ['', '42', 'a', 'z'].each do |order|
-      context '\'\'' do
+      context "'#{order}'" do
         it_behaves_like 'fragment', 'motd_header', {
           :order  => order,
           :target => '/etc/motd',

--- a/spec/defines/concat_spec.rb
+++ b/spec/defines/concat_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'concat', :type => :define do
+describe 'concat' do
 
   shared_examples 'concat' do |title, params, id|
     params = {} if params.nil?


### PR DESCRIPTION
When defines are in spec/defines then rspec-puppet automatically includes the define checks according to https://github.com/rodjek/rspec-puppet/blob/3c16670252f3cf309037f1e0cd3fa71f903bef68/lib/rspec-puppet/example.rb#L22