### PR TITLE
Added Debian Stretch (9) to the supported list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
Should there be a discussion first if you want to support Debain Stretch?
In any way, Stretch is the new stable for Debian and I dont see any reason not to support it.

We run and tested it on Debian Stretch and we haven't found any issue as of yet.