### PR TITLE
Updating metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "10 SP4",
         "11 SP1",
         "12"
       ]
@@ -77,7 +76,6 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2003 R2",
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2"
@@ -94,7 +92,8 @@
     {
       "operatingsystem": "OSX",
       "operatingsystemrelease": [
-        "10.9"
+        "10.10",
+        "10.11"
       ]
     }
   ],


### PR DESCRIPTION
Removing SLES 10, Windows 2003 R2 and OSX 10.9.
Adding OSX 10.10 and 10.11.

These changes are to reflect https://puppet.com/docs/pe/2017.3/installing/supported_operating_systems.html.