### PR TITLE
(maint) Fix typo in sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -11,7 +11,7 @@ appveyor.yml:
       RUBY_VER: 23-x64
 spec/spec_helper.rb:
   allow_deprecations: true
- .travis.yml:
+  .travis.yml:
    extras:
    - rvm: 2.1.9
      script: bundle exec rake rubocop 


### PR DESCRIPTION
Previously in commit b56360e95dfa19ebfa24b5dd1035fdfe0c8b97c6 the sync.yml was
updated to include rubocop testing, however the yml was invalid due to missing
whitespace.  This caused the modulesync_configs testing to fail.  This commit
fixes the whitespace.

[skip ci]