### PR TITLE
(MODULES-7717) ensure_newline uses unix line ending on windows

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -255,7 +255,8 @@ Puppet::Type.newtype(:concat_file) do
     end
 
     if self[:ensure_newline]
-      fragment_content << "\n" unless fragment_content =~ %r{\n$}
+      newline = Puppet::Util::Platform.windows? ? "\r\n" : "\n"
+      fragment_content << newline unless fragment_content =~ %r{#{newline}$}
     end
 
     fragment_content

--- a/spec/acceptance/newline_spec.rb
+++ b/spec/acceptance/newline_spec.rb
@@ -58,9 +58,10 @@ describe 'concat ensure_newline parameter' do
     end
 
     describe file("#{basedir}/file") do
+      newline = (fact('operatingsystem') == 'windows') ? "\r\n" : "\n"
       it { is_expected.to be_file }
       its(:content) do
-        is_expected.to match %r{1\n2\n}
+        is_expected.to match %r{1#{newline}2#{newline}}
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, ensure_newline used '\n' everywhere.
With this commit, ensure_newline uses '\r\n' on Windows.