### PR TITLE
(MODULES-7790) Fix modifying frozen string literal

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -255,7 +255,8 @@ Puppet::Type.newtype(:concat_file) do
     end
 
     if self[:ensure_newline]
-      fragment_content << "\n" unless fragment_content =~ %r{\n$}
+      # Avoid trying to modify a frozen string
+      fragment_content = "#{fragment_content}\n" unless fragment_content =~ %r{\n$}
     end
 
     fragment_content


### PR DESCRIPTION
In Puppet 6, PUP-7141 changed the 3x runtime to stop duplicating
strings. Providers will now usually receive frozen strings. Update the
concat_file provider to create a new copy of a string if it needs to add
to it rather than attempt to mutate the original.