### PR TITLE
Revert "(MODULES-7790) Fix modifying frozen string literal"

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -255,8 +255,7 @@ Puppet::Type.newtype(:concat_file) do
     end
 
     if self[:ensure_newline]
-      # Avoid trying to modify a frozen string
-      fragment_content = "#{fragment_content}\n" unless fragment_content =~ %r{\n$}
+      fragment_content << "\n" unless fragment_content =~ %r{\n$}
     end
 
     fragment_content


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-concat#521

The change that caused this in Puppet was reverted in https://github.com/puppetlabs/puppet/commit/16963e37d4e06564981725f8b87d836f715a42dc and https://github.com/puppetlabs/puppet/pull/7073.