### PR TITLE
Revert "(MODULES-7717) ensure_newline uses unix line ending on windows"

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -255,8 +255,7 @@ Puppet::Type.newtype(:concat_file) do
     end
 
     if self[:ensure_newline]
-      newline = Puppet::Util::Platform.windows? ? "\r\n" : "\n"
-      fragment_content << newline unless fragment_content =~ %r{#{newline}$}
+      fragment_content << "\n" unless fragment_content =~ %r{\n$}
     end
 
     fragment_content

--- a/spec/acceptance/newline_spec.rb
+++ b/spec/acceptance/newline_spec.rb
@@ -58,10 +58,9 @@ describe 'concat ensure_newline parameter' do
     end
 
     describe file("#{basedir}/file") do
-      newline = (fact('operatingsystem') == 'windows') ? "\r\n" : "\n"
       it { is_expected.to be_file }
       its(:content) do
-        is_expected.to match %r{1#{newline}2#{newline}}
+        is_expected.to match %r{1\n2\n}
       end
     end
   end


### PR DESCRIPTION
This reverts commit 0a6e416e37b5493825b22e6e803deffbda26633d to unblock
the agent suite pipelines until MODULES-8088 is fixed.