### PR TITLE
(MODULES-8088) - newline_spec.rb test expectation update

### DIFF
--- a/spec/acceptance/newline_spec.rb
+++ b/spec/acceptance/newline_spec.rb
@@ -58,10 +58,9 @@ describe 'concat ensure_newline parameter' do
     end
 
     describe file("#{basedir}/file") do
-      newline = (fact('operatingsystem') == 'windows') ? "\r\n" : "\n"
       it { is_expected.to be_file }
       its(:content) do
-        is_expected.to match %r{1#{newline}2#{newline}}
+        is_expected.to match %r{1\n2\n}
       end
     end
   end


### PR DESCRIPTION
Fix `ensure_newline` acceptance test for windows2012r2-64default.a 