### PR TITLE
(maint) - Normalise Windows OS Names

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -77,12 +77,12 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2008 R2",
-        "Server 2012",
-        "Server 2012 R2",
-        "Server 2016",
-        "Server 2012 R2 Core",
-        "Server 2016 Core",
+        "2008 R2",
+        "2012",
+        "2012 R2",
+        "2016",
+        "2012 R2 Core",
+        "2016 Core",
         "7",
         "8.1",
         "10"


### PR DESCRIPTION
Changing windows OS support names to match the rest of our supported modules.