### PR TITLE
(MODULES-9479) Fix nested array merge behavior

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -275,6 +275,8 @@ Puppet::Type.newtype(:concat_file) do
     hash1.merge(hash2) do |k, v1, v2|
       if v1.is_a?(Hash) && v2.is_a?(Hash)
         nested_merge(v1, v2)
+      elsif v1.is_a?(Array) && v2.is_a?(Array)
+        nested_merge(v1, v2)
       else
         # Fail if there are duplicate keys without force
         unless v1 == v2

--- a/spec/acceptance/force_spec.rb
+++ b/spec/acceptance/force_spec.rb
@@ -141,7 +141,7 @@ describe 'force merge of file' do
     it 'applies the manifest twice with no stderr' do
       idempotent_apply(pp)
       expect(file("#{@basedir}/file")).to be_file
-      expect(file("#{@basedir}/file").content).to match '{"one": "foo"}{"one": "bar"}'
+      expect(file("#{@basedir}/file").content).to contain '{"one":[1,2]}'
     end
   end
 end

--- a/spec/acceptance/force_spec.rb
+++ b/spec/acceptance/force_spec.rb
@@ -91,6 +91,33 @@ describe 'force merge of file' do
     end
   end
 
+  describe 'when run should force merge nested arrays' do
+    let(:pp) do
+      <<-MANIFEST
+        concat { '#{@basedir}/file':
+          format => 'json',
+          force => true,
+        }
+
+        concat::fragment { '1':
+          target  => '#{@basedir}/file',
+          content => '{"one": [1]}',
+        }
+
+        concat::fragment { '2':
+          target  => '#{@basedir}/file',
+          content => '{"one": [2]}',
+        }
+      MANIFEST
+    end
+
+    it 'applies the manifest twice with no stderr' do
+      idempotent_apply(pp)
+      expect(file("#{@basedir}/file")).to be_file
+      expect(file("#{@basedir}/file").content).to match '{"one":[1,2]}'
+    end
+  end
+
   describe 'when run should not force on plain' do
     let(:pp) do
       <<-MANIFEST

--- a/spec/acceptance/force_spec.rb
+++ b/spec/acceptance/force_spec.rb
@@ -114,7 +114,7 @@ describe 'force merge of file' do
     it 'applies the manifest twice with no stderr' do
       idempotent_apply(pp)
       expect(file("#{@basedir}/file")).to be_file
-      expect(file("#{@basedir}/file").content).to match '{"one":[1,2]}\R?'
+      expect(file("#{@basedir}/file").content).to match "{"one":[1,2]}\R?"
     end
   end
 

--- a/spec/acceptance/force_spec.rb
+++ b/spec/acceptance/force_spec.rb
@@ -114,7 +114,7 @@ describe 'force merge of file' do
     it 'applies the manifest twice with no stderr' do
       idempotent_apply(pp)
       expect(file("#{@basedir}/file")).to be_file
-      expect(file("#{@basedir}/file").content).to match '{"one":[1,2]}' || '{"one":[1,2]}\n'
+      expect(file("#{@basedir}/file").content).to match '{"one":[1,2]}\R?'
     end
   end
 

--- a/spec/acceptance/force_spec.rb
+++ b/spec/acceptance/force_spec.rb
@@ -114,7 +114,7 @@ describe 'force merge of file' do
     it 'applies the manifest twice with no stderr' do
       idempotent_apply(pp)
       expect(file("#{@basedir}/file")).to be_file
-      expect(file("#{@basedir}/file").content).to match '{"one":[1,2]}'
+      expect(file("#{@basedir}/file").content).to match '{"one":[1,2]}' || '{"one":[1,2]}\n'
     end
   end
 

--- a/spec/acceptance/force_spec.rb
+++ b/spec/acceptance/force_spec.rb
@@ -114,7 +114,7 @@ describe 'force merge of file' do
     it 'applies the manifest twice with no stderr' do
       idempotent_apply(pp)
       expect(file("#{@basedir}/file")).to be_file
-      expect(file("#{@basedir}/file").content).to contain '{"one":[1,2]}'
+      expect(file("#{@basedir}/file").content).to contain '{"one":\[1,2\]}'
     end
   end
 

--- a/spec/acceptance/force_spec.rb
+++ b/spec/acceptance/force_spec.rb
@@ -114,7 +114,7 @@ describe 'force merge of file' do
     it 'applies the manifest twice with no stderr' do
       idempotent_apply(pp)
       expect(file("#{@basedir}/file")).to be_file
-      expect(file("#{@basedir}/file").content).to match "{"one":[1,2]}\R?"
+      expect(file("#{@basedir}/file").content).to contain '{"one":[1,2]}'
     end
   end
 
@@ -141,7 +141,7 @@ describe 'force merge of file' do
     it 'applies the manifest twice with no stderr' do
       idempotent_apply(pp)
       expect(file("#{@basedir}/file")).to be_file
-      expect(file("#{@basedir}/file").content).to contain '{"one":[1,2]}'
+      expect(file("#{@basedir}/file").content).to match '{"one": "foo"}{"one": "bar"}'
     end
   end
 end


### PR DESCRIPTION
Fix regression in behavior introduced in the 5.2.0 release
with the fix for MODULES-8287. Restore the behavior where arrays
nested inside hashes will be merged.