### PR TITLE
PDK Update to remove PDK-1525 workaround

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
-gem 'pdk', git: 'https://github.com/puppetlabs/pdk.git', branch: 'master'
 
 def location_for(place_or_version, fake_version = nil)
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}

--- a/metadata.json
+++ b/metadata.json
@@ -110,6 +110,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates/#master",
-  "template-ref": "heads/master-0-g0b5b39b",
+  "template-ref": "heads/master-0-g0e670e6",
   "pdk-version": "1.14.0"
 }


### PR DESCRIPTION
## Description
This PR is the result of a `pdk update` to ensure that [this change](https://github.com/puppetlabs/puppetlabs-mysql/commit/0813f47bf8709526697d2cd88c0a99301f6666a3) is reverted and the module points to the latest released version of `pdk` now.