### PR TITLE
Fix newline handling at the end of fragments

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -312,7 +312,7 @@ Puppet::Type.newtype(:concat_file) do
 
     if self[:ensure_newline]
       newline = Puppet::Util::Platform.windows? ? "\r\n" : "\n"
-      fragment_content << newline unless fragment_content =~ %r{#{newline}$}
+      fragment_content << newline unless fragment_content =~ %r{#{newline}\Z}
     end
 
     fragment_content


### PR DESCRIPTION
`$` matches both end of string and end of line.
so `/\n$/` matches `\n\n` anywhere in the string.
while `/\n\Z/` only matches `\n` at the end of the string.

```
irb(main):021:0> "a\n\nb" =~ /\n$/
=> 1
irb(main):022:0> "a\n\nb" =~ /\n\Z/
=> nil
irb(main):023:0> "a\n\nb\n" =~ /\n$/
=> 1
irb(main):024:0> "a\n\nb\n" =~ /\n\Z/
=> 4
```