### PR TITLE
Add support for Deferred function in concat fragment

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -211,9 +211,10 @@ The following parameters are available in the `concat::fragment` defined type.
 
 ##### `content`
 
-Data type: `Optional[String]`
+Data type: `Optional[Any]`
 
 Supplies the content of the fragment. Note: You must supply either a content parameter or a source parameter.
+Allows a String or a Deferred function which returns a String.
 
 Default value: `undef`
 

--- a/spec/defines/concat_fragment_spec.rb
+++ b/spec/defines/concat_fragment_spec.rb
@@ -67,7 +67,7 @@ describe 'concat::fragment' do
       let(:params) { { content: false, target: '/etc/motd' } }
 
       it 'fails' do
-        expect { catalogue }.to raise_error(Puppet::Error, %r{parameter 'content' expects a .*String.*})
+        expect { catalogue }.to raise_error(Puppet::Error, %r{expects a value of type Undef( or String|, String, or Deferred), got Boolean})
       end
     end
   end


### PR DESCRIPTION
This allows the `content` parameter of `concat::fragment` to be an `Deferred` function.