### PR TITLE
(MODULES-9711) Consistently manage concat with no fragments

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -354,7 +354,7 @@ Puppet::Type.newtype(:concat_file) do
   def eval_generate
     content = should_content
 
-    if !content.nil? && !content.empty?
+    unless content.nil?
       catalog.resource("File[#{self[:path]}]")[:content] = content
     end
 

--- a/spec/acceptance/concat_spec.rb
+++ b/spec/acceptance/concat_spec.rb
@@ -78,6 +78,24 @@ describe 'basic concat test' do
     end
   end
 
+  describe 'with no fragments declared' do
+    let(:pp) do
+      <<-MANIFEST
+        concat { 'file':
+          ensure => present,
+          path   => '#{@basedir}/file',
+          mode   => '0644',
+        }
+      MANIFEST
+    end
+
+    it 'applies manifest twice with no stderr' do
+      idempotent_apply(pp)
+      expect(file("#{@basedir}/file")).to be_file
+      expect(file("#{@basedir}/file").content).to eq ''
+    end
+  end
+
   describe 'when absent with path set' do
     let(:pp) do
       <<-MANIFEST


### PR DESCRIPTION
When no concat_fragment resources are specified, concat_file
should manage an empty file. This resolves MODULES-9711 and
MODULES-7371.