### PR TITLE
pdksync - (maint) Remove RHEL 5, SLES 11, 12 support; Clean up OS naming in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -30,7 +29,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -39,7 +37,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -54,8 +51,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11 SP1",
-        "12",
         "15"
       ]
     },
@@ -86,13 +81,14 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
+        "2008",
         "2008 R2",
         "2012",
         "2012 R2",
         "2016",
-        "2012 R2 Core",
+        "2019",
         "7",
-        "8.1",
+        "8",
         "10"
       ]
     },


### PR DESCRIPTION
(maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json
pdk version: `1.18.1` 
