### PR TITLE
pdksync - (MAINT) Remove RHEL 5 family support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -30,7 +29,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -39,7 +37,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]


### PR DESCRIPTION
(MAINT) Remove RHEL 5 family support
pdk version: `1.18.1` 
