### PR TITLE
Do not modify metaparams in place

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -341,13 +341,12 @@ Puppet::Type.newtype(:concat_file) do
       file_opts[param] = self[param] unless self[param].nil?
     end
 
-    metaparams = Puppet::Type.metaparams
     excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
 
-    metaparams.reject! { |param| excluded_metaparams.include? param }
-
-    metaparams.each do |metaparam|
-      file_opts[metaparam] = self[metaparam] unless self[metaparam].nil?
+    Puppet::Type.metaparams.each do |metaparam|
+      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
+        file_opts[metaparam] = self[metaparam]
+      end
     end
 
     [Puppet::Type.type(:file).new(file_opts)]


### PR DESCRIPTION
This can have unexpected side effects and break other code that relies on it. This takes a safer approach by iterating over it.

Fixes: dd88b1a4eee853cfff60b99096c05ce85a9d556e