### PR TITLE
fix merge nil hashes

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -264,9 +264,9 @@ Puppet::Type.newtype(:concat_file) do
   end
 
   def nested_merge(hash1, hash2)
-    # If a hash is empty, simply return the other
-    return hash1 if hash2.empty?
-    return hash2 if hash1.empty?
+    # If a hash is nil or empty, simply return the other
+    return hash1 if hash2.nil? || hash2.empty?
+    return hash2 if hash1.nil? || hash1.empty?
 
     # Unique merge for arrays
     if hash1.is_a?(Array) && hash2.is_a?(Array)


### PR DESCRIPTION
Apparently it can be the case that one of the hashes is nil. I added a nil check in the merge function.

```
Error: /Stage[main]/xxx::Config/Concat[/etc/file/config.yml]/Concat_file[/etc/file/config.yml]: Failed to generate additional resources us
ing 'eval_generate': undefined method `empty?' for nil:NilClass
/opt/puppetlabs/puppet/cache/lib/puppet/type/concat_file.rb:266:in `nested_merge'
/opt/puppetlabs/puppet/cache/lib/puppet/type/concat_file.rb:232:in `block in should_content'
/opt/puppetlabs/puppet/cache/lib/puppet/type/concat_file.rb:231:in `each'
/opt/puppetlabs/puppet/cache/lib/puppet/type/concat_file.rb:231:in `reduce'
/opt/puppetlabs/puppet/cache/lib/puppet/type/concat_file.rb:231:in `should_content'
/opt/puppetlabs/puppet/cache/lib/puppet/type/concat_file.rb:355:in `eval_generate'
```