### PR TITLE
(maint) harden test setup

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -26,6 +26,6 @@ def setup_test_directory
       force   => true,
     }
   MANIFEST
-  LitmusHelper.instance.apply_manifest(pp)
+  LitmusHelper.instance.apply_manifest(pp, expect_failures: false)
   basedir
 end


### PR DESCRIPTION
We are currently seeing transient errors where tests are executed but the setup hasn't happened which then causes failures. This will enable us to debug easier and fail at the correct point in time. Also it will avoid tests executing before the files are created because it needs the LitmusHelper execution to complete before it can evaluate if there have been failures or not.