### PR TITLE
pdksync - (FM-8922) Add Support for Windows 2022

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -78,14 +78,15 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
+        "7",
+        "8.1",
+        "10",
         "2008 R2",
+        "2012 R2 Core",
         "2012",
         "2012 R2",
         "2016",
-        "2012 R2 Core",
-        "7",
-        "8.1",
-        "10"
+        "2022"
       ]
     },
     {


### PR DESCRIPTION
(FM-8922) Add Support for Windows 2022
pdk version: `2.1.0` 
