### PR TITLE
pdksync - (CONT-130) Dropping Support for Debian 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10",
         "11"
       ]


### PR DESCRIPTION
Dropping Support for Debian 9
pdk version: `2.3.0` 
