### PR TITLE
pdksync - (CONT-494) Pin github_changelog_generator and JSON gem versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -106,6 +106,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-g9a16c87",
+  "template-ref": "2.7.1-0-g9a16c87",
   "pdk-version": "2.5.0"
 }


### PR DESCRIPTION
CONT-494/pin_github_changelog_generator
pdk version: `2.5.0` 
