### PR TITLE
(MODULES-3522) Removing redundant 'requires'

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-require 'puppet/type/file/owner'
-require 'puppet/type/file/group'
-require 'puppet/type/file/mode'
+# require 'puppet/type/file/owner'
+# require 'puppet/type/file/group'
+# require 'puppet/type/file/mode'
+Puppet::Type.type(:file)
 require 'puppet/util/checksums'
 
 Puppet::Type.newtype(:concat_file) do

--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# require 'puppet/type/file/owner'
-# require 'puppet/type/file/group'
-# require 'puppet/type/file/mode'
-Puppet::Type.type(:file)
 require 'puppet/util/checksums'
 
 Puppet::Type.newtype(:concat_file) do


### PR DESCRIPTION
Prior to this commit, there was an issue regarding the loading of the puppet/type/file/owner constant under certain circumstances during agent runs.

This commit aims to modernise the file request to comply with best practices.