### PR TITLE
Revert "(MODULES-3522) Removing redundant 'requires'"

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'puppet/type/file/owner'
+require 'puppet/type/file/group'
+require 'puppet/type/file/mode'
 require 'puppet/util/checksums'
 
 Puppet::Type.newtype(:concat_file) do


### PR DESCRIPTION
As established in #758, this update caused an unexpected regression. Reverts puppetlabs/puppetlabs-concat#755