### PR TITLE
Add parameter to not create empty files when no fragments are defined

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -246,7 +246,7 @@ The following parameters are available in the `concat::fragment` defined type:
 
 ##### <a name="-concat--fragment--content"></a>`content`
 
-Data type: `Optional[Any]`
+Data type: `Optional[Variant[String, Deferred]]`
 
 Supplies the content of the fragment. Note: You must supply either a content parameter or a source parameter.
 Allows a String or a Deferred function which returns a String.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,6 +56,7 @@ The following parameters are available in the `concat` defined type:
 * [`show_diff`](#-concat--show_diff)
 * [`validate_cmd`](#-concat--validate_cmd)
 * [`warn`](#-concat--warn)
+* [`create_empty_file`](#-concat--create_empty_file)
 
 ##### <a name="-concat--backup"></a>`backup`
 
@@ -222,6 +223,14 @@ it explicitly if you need it.
 
 Default value: `false`
 
+##### <a name="-concat--create_empty_file"></a>`create_empty_file`
+
+Data type: `Boolean`
+
+Specifies whether to create an empty file if no fragments are defined. Defaults to true.
+
+Default value: `true`
+
 ### <a name="concat--fragment"></a>`concat::fragment`
 
 Manages a fragment of text to be compiled into a file.
@@ -310,6 +319,7 @@ Default value: `present`
 The following parameters are available in the `concat_file` type.
 
 * [`backup`](#-concat_file--backup)
+* [`create_empty_file`](#-concat_file--create_empty_file)
 * [`ensure_newline`](#-concat_file--ensure_newline)
 * [`force`](#-concat_file--force)
 * [`format`](#-concat_file--format)
@@ -335,6 +345,14 @@ native file
 resource for execution. Valid options: true, false, or a string representing either a target filebucket or a filename
 extension
 beginning with ".".'
+
+##### <a name="-concat_file--create_empty_file"></a>`create_empty_file`
+
+Valid values: `true`, `false`, `yes`, `no`
+
+Specifies whether to create an empty file if no fragments are defined.
+
+Default value: `true`
 
 ##### <a name="-concat_file--ensure_newline"></a>`ensure_newline`
 

--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -181,6 +181,11 @@ Puppet::Type.newtype(:concat_file) do
     DOC
   end
 
+  newparam(:create_empty_file, boolean: true, parent: Puppet::Parameter::Boolean) do
+    desc 'Specifies whether to create an empty file if no fragments are defined.'
+    defaultto true
+  end
+
   # Autorequire the file we are generating below
   # Why is this necessary ?
   autorequire(:file) do
@@ -357,6 +362,10 @@ Puppet::Type.newtype(:concat_file) do
 
     unless content.nil?
       catalog.resource("File[#{self[:path]}]")[:content] = content
+    end
+
+    if !self[:create_empty_file] && (content.nil? || content.empty?)
+      catalog.resource("File[#{self[:path]}]")[:ensure] = :absent
     end
 
     [catalog.resource("File[#{self[:path]}]")]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,9 @@
 #   Before 2.0.0, this parameter would add a newline at the end of the warn message. To improve flexibilty, this was removed. Please add
 #   it explicitly if you need it.
 #
+# @param create_empty_file
+#   Specifies whether to create an empty file if no fragments are defined. Defaults to true.
+#
 define concat (
   Enum['present', 'absent']          $ensure                  = 'present',
   Stdlib::Absolutepath               $path                    = $name,
@@ -99,6 +102,7 @@ define concat (
   Optional[String]                   $seluser                 = undef,
   Optional[String]                   $format                  = 'plain',
   Optional[Boolean]                  $force                   = false,
+  Boolean                            $create_empty_file       = true,
 ) {
   $safe_name            = regsubst($name, '[\\\\/:~\n\s\+\*\(\)@]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"
@@ -138,6 +142,7 @@ define concat (
       validate_cmd            => $validate_cmd,
       format                  => $format,
       force                   => $force,
+      create_empty_file       => $create_empty_file,
     }
 
     if $_append_header {

--- a/spec/acceptance/concat_spec.rb
+++ b/spec/acceptance/concat_spec.rb
@@ -100,6 +100,24 @@ describe 'basic concat test' do
     end
   end
 
+  describe 'with no fragments declared and create_empty_file = false' do
+    let(:pp) do
+      <<-MANIFEST
+        concat { 'file':
+          ensure            => present,
+          path              => '#{basedir}/file',
+          mode              => '0644',
+          create_empty_file => false,
+        }
+      MANIFEST
+    end
+
+    it 'applies the manifest twice with no stderr' do
+      idempotent_apply(pp)
+      expect(file("#{basedir}/file")).not_to be_file
+    end
+  end
+
   describe 'when absent with path set' do
     let(:pp) do
       <<-MANIFEST

--- a/spec/unit/type/concat_file_spec.rb
+++ b/spec/unit/type/concat_file_spec.rb
@@ -149,4 +149,8 @@ describe Puppet::Type.type(:concat_file) do
       expect { resource[:format] = 'bar' }.to raise_error(%r{Invalid value "bar"})
     end
   end
+
+  describe 'parameter :create_empty_file' do
+    it_behaves_like 'Puppet::Parameter::Boolean', :create_empty_file
+  end
 end


### PR DESCRIPTION
By default concat would always create an empty file if no fragment was defined. Sometimes we don't want a file unless it has content.