### PR TITLE
(CONT-874) Update changelog to address wrong title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
 
-- \(CONT-775\) Puppet 8 support [\#768](https://github.com/puppetlabs/puppetlabs-concat/pull/768) ([LukasAud](https://github.com/LukasAud))
+- (CONT-775) Puppet 8 support / Drop Puppet 6 support [#768](https://github.com/puppetlabs/puppetlabs-concat/pull/768) ([LukasAud](https://github.com/LukasAud))
 
 ## [v7.4.0](https://github.com/puppetlabs/puppetlabs-concat/tree/v7.4.0) (2023-04-12)
 


### PR DESCRIPTION
Prior to this commit, it was brought to light an error in PR naming for Puppet 8 support related PRs, where they failed to mention the potential drop in Puppet 6 support. This commit aims to fix the changelog so that it reflects better the changes made in this major update.