### PR TITLE
(MAINT) Addressing wrong Rubocop TargetRubyVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: '2.7'
+  TargetRubyVersion: '2.6'
   ExtraDetails: true
   DisplayStyleGuide: true
   Include:

--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -190,14 +190,14 @@ Puppet::Type.newtype(:concat_file) do
 
   def fragments
     # Collect fragments that target this resource by path, title or tag.
-    @fragments ||= catalog.resources.filter_map do |resource|
+    @fragments ||= catalog.resources.map { |resource|
       next unless resource.is_a?(Puppet::Type.type(:concat_fragment))
 
       if resource[:target] == self[:path] || resource[:target] == title ||
          (resource[:tag] && resource[:tag] == self[:tag])
         resource
       end
-    end
+    }.compact
   end
 
   def decompound(d)


### PR DESCRIPTION
Prior to this commit, during the Puppet 8 support work, TargetRubyVersion was set to 2.7 and a cop rule was addressed according to it. However, the correct ruby version is 2.6.

This commit aims to address the previously wrongly set version along with an unnecesary change that breaks some compatibility with 2.6 systems.