### PR TITLE
Revert "Correct Naming/AccessorMethodName"

### DIFF
--- a/lib/puppet/type/concat_fragment.rb
+++ b/lib/puppet/type/concat_fragment.rb
@@ -95,7 +95,7 @@ Puppet::Type.newtype(:concat_fragment) do
     raise Puppet::ParseError, _("Can't use 'source' and 'content' at the same time") if !self[:source].nil? && !self[:content].nil?
   end
 
-  def sensitive_parameters=(sensitive_parameters)
+  def set_sensitive_parameters(sensitive_parameters) # rubocop:disable Naming/AccessorMethodName
     # Respect sensitive https://tickets.puppetlabs.com/browse/PUP-10950
     if sensitive_parameters.include?(:content)
       sensitive_parameters.delete(:content)


### PR DESCRIPTION
This reverts commit bc6478ae57ac25be6a53c8c64eca179853c3a598.

The API is `sensitive_parameters`, we can't just change the name of this method in this type because rubocop complains.