### PR TITLE
Allow user defined tag or list of tags

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -8,19 +8,29 @@ require 'puppet/util/checksums'
 Puppet::Type.newtype(:concat_file) do
   @doc = <<-DOC
     @summary
-      Generates a file with content from fragments sharing a common unique tag.
+      Generates a file with content from fragments sharing a single or a list of common unique tag(s).
 
     @example
       Concat_fragment <<| tag == 'unique_tag' |>>
+      Concat_fragment <<| tag == 'other_tag' |>>
 
       concat_file { '/tmp/file':
         tag            => 'unique_tag', # Optional. Default to undef
         path           => '/tmp/file',  # Optional. If given it overrides the resource name
         owner          => 'root',       # Optional. Default to undef
         group          => 'root',       # Optional. Default to undef
-        mode           => '0644'        # Optional. Default to undef
-        order          => 'numeric'     # Optional, Default to 'numeric'
+        mode           => '0644',       # Optional. Default to undef
+        order          => 'numeric',    # Optional, Default to 'numeric'
         ensure_newline => false         # Optional, Defaults to false
+      }
+      concat_file { '/tmp/file2':
+        tag            => ['unique_tag', 'other_tag'],
+        path           => '/tmp/file2',
+        owner          => 'root',
+        group          => 'root',
+        mode           => '0644',
+        order          => 'numeric',
+        ensure_newline => false
       }
   DOC
 
@@ -40,7 +50,7 @@ Puppet::Type.newtype(:concat_file) do
   end
 
   newparam(:tag) do
-    desc 'Required. Specifies a unique tag reference to collect all concat_fragments with the same tag.'
+    desc 'Specifies a single or a list of unique tag reference(s) to collect all concat_fragments with the same tag(s).'
   end
 
   newparam(:path, namevar: true) do
@@ -194,7 +204,7 @@ Puppet::Type.newtype(:concat_file) do
       next unless resource.is_a?(Puppet::Type.type(:concat_fragment))
 
       if resource[:target] == self[:path] || resource[:target] == title ||
-         (resource[:tag] && resource[:tag] == self[:tag])
+         ((resource[:tag] && self[:tag]) && (resource[:tag] == self[:tag] || self[:tag].is_a?(Array) && self[:tag].include?(resource[:tag])))
         resource
       end
     }.compact

--- a/lib/puppet/type/concat_fragment.rb
+++ b/lib/puppet/type/concat_fragment.rb
@@ -75,7 +75,7 @@ Puppet::Type.newtype(:concat_fragment) do
       next unless resource.is_a?(Puppet::Type.type(:concat_file))
 
       resource[:path] == self[:target] || resource.title == self[:target] ||
-        (resource[:tag] && resource[:tag] == self[:tag])
+        ((resource[:tag] && self[:tag]) && (resource[:tag] == self[:tag] || resource[:tag].is_a?(Array) && resource[:tag].include?(self[:tag])))
     end
 
     if found.empty?

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -16,14 +16,14 @@
 # @param target
 #   Specifies the destination file of the fragment. Valid options: a string containing the path or title of the parent concat resource.
 #
-# @param tag
+# @param tagging
 #   Specifies a custom tag to use for the fragment.
 #
 define concat::fragment (
   String                                                 $target,
   Optional[Variant[Sensitive[String], String, Deferred]] $content = undef,
   Optional[Variant[String, Array]]                       $source  = undef,
-  Optional[String[1]]                                    $tag     = undef,
+  Optional[String[1]]                                    $tagging = undef,
   Variant[String, Integer]                               $order   = '10',
 ) {
   $resource = 'Concat::Fragment'
@@ -38,10 +38,10 @@ define concat::fragment (
     fail("${resource}['${title}']: Can't use 'source' and 'content' at the same time.")
   }
 
-  if $tag =~ Undef {
+  if $tagging =~ Undef {
     $safe_target_name = regsubst($target, '[\\\\/:~\n\s\+\*\(\)@]', '_', 'GM')
   } else {
-    $safe_target_name = $tag
+    $safe_target_name = $tagging
   }
 
   concat_fragment { $name:

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -16,10 +16,14 @@
 # @param target
 #   Specifies the destination file of the fragment. Valid options: a string containing the path or title of the parent concat resource.
 #
+# @param tag
+#   Specifies a custom tag to use for the fragment.
+#
 define concat::fragment (
   String                                                 $target,
   Optional[Variant[Sensitive[String], String, Deferred]] $content = undef,
   Optional[Variant[String, Array]]                       $source  = undef,
+  Optional[String[1]]                                    $tag     = undef,
   Variant[String, Integer]                               $order   = '10',
 ) {
   $resource = 'Concat::Fragment'
@@ -34,7 +38,11 @@ define concat::fragment (
     fail("${resource}['${title}']: Can't use 'source' and 'content' at the same time.")
   }
 
-  $safe_target_name = regsubst($target, '[\\\\/:~\n\s\+\*\(\)@]', '_', 'GM')
+  if $tag =~ Undef {
+    $safe_target_name = regsubst($target, '[\\\\/:~\n\s\+\*\(\)@]', '_', 'GM')
+  } else {
+    $safe_target_name = $tag
+  }
 
   concat_fragment { $name:
     target  => $target,

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -38,10 +38,10 @@ define concat::fragment (
     fail("${resource}['${title}']: Can't use 'source' and 'content' at the same time.")
   }
 
-  if $tagging =~ Undef {
-    $safe_target_name = regsubst($target, '[\\\\/:~\n\s\+\*\(\)@]', '_', 'GM')
-  } else {
+  if $tagging {
     $safe_target_name = $tagging
+  } else {
+    $safe_target_name = regsubst($target, '[\\\\/:~\n\s\+\*\(\)@]', '_', 'GM')
   }
 
   concat_fragment { $name:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,9 @@
 # @param create_empty_file
 #   Specifies whether to create an empty file if no fragments are defined. Defaults to true.
 #
+# @param tag
+#   Specifies a custom tag or list of custom tags for gatherinng the fragments to combine.
+#
 define concat (
   Enum['present', 'absent']          $ensure                  = 'present',
   Stdlib::Absolutepath               $path                    = $name,
@@ -103,6 +106,7 @@ define concat (
   Boolean                            $force                   = false,
   Boolean                            $create_empty_file       = true,
   Enum['plain', 'yaml', 'json', 'json-array', 'json-pretty', 'json-array-pretty'] $format = 'plain',
+  Optional[Variant[String[1], Array[String[1], 1]]]                               $tag    = undef,
 ) {
   $safe_name            = regsubst($name, '[\\\\/:~\n\s\+\*\(\)@]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"
@@ -122,9 +126,15 @@ define concat (
     }
   }
 
+  if $tag =~ Undef {
+    $safe_names = $safe_name
+  } else {
+    $safe_names = flatten($safe_name, $tag)
+  }
+
   if $ensure == 'present' {
     concat_file { $name:
-      tag                     => $safe_name,
+      tag                     => $safe_names,
       path                    => $path,
       owner                   => $owner,
       group                   => $group,
@@ -156,7 +166,7 @@ define concat (
   } else {
     concat_file { $name:
       ensure => $ensure,
-      tag    => $safe_name,
+      tag    => $safe_names,
       path   => $path,
       backup => $backup,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,8 +82,8 @@
 # @param create_empty_file
 #   Specifies whether to create an empty file if no fragments are defined. Defaults to true.
 #
-# @param tag
-#   Specifies a custom tag or list of custom tags for gatherinng the fragments to combine.
+# @param tagging
+#   Specifies a custom tag or list of custom tags for gathering the fragments to combine.
 #
 define concat (
   Enum['present', 'absent']          $ensure                  = 'present',
@@ -105,8 +105,8 @@ define concat (
   Optional[String]                   $seluser                 = undef,
   Boolean                            $force                   = false,
   Boolean                            $create_empty_file       = true,
-  Enum['plain', 'yaml', 'json', 'json-array', 'json-pretty', 'json-array-pretty'] $format = 'plain',
-  Optional[Variant[String[1], Array[String[1], 1]]]                               $tag    = undef,
+  Enum['plain', 'yaml', 'json', 'json-array', 'json-pretty', 'json-array-pretty'] $format  = 'plain',
+  Optional[Variant[String[1], Array[String[1], 1]]]                               $tagging = undef,
 ) {
   $safe_name            = regsubst($name, '[\\\\/:~\n\s\+\*\(\)@]', '_', 'G')
   $default_warn_message = "# This file is managed by Puppet. DO NOT EDIT.\n"
@@ -126,10 +126,10 @@ define concat (
     }
   }
 
-  if $tag =~ Undef {
+  if $tagging =~ Undef {
     $safe_names = $safe_name
   } else {
-    $safe_names = flatten($safe_name, $tag)
+    $safe_names = flatten($safe_name, $tagging)
   }
 
   if $ensure == 'present' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,10 +126,10 @@ define concat (
     }
   }
 
-  if $tagging =~ Undef {
-    $safe_names = $safe_name
-  } else {
+  if $tagging {
     $safe_names = flatten($safe_name, $tagging)
+  } else {
+    $safe_names = $safe_name
   }
 
   if $ensure == 'present' {


### PR DESCRIPTION
## Summary
- Allow native types to handle a list of tags  
  speaking: allow a `concat_file` to get assembled of fragments matching the list of tags
- Make the `tag` (optionally) configurable for the Puppet defined types (`concat`/`concat::fragment`)

## Additional Context
Generating fragments for a target path is one thing but generating snippets in a more "neutral" or "generic" way (not tied to the path) has plenty of additional use cases not covered by this method. Best example are multiple certificate authority hosts exporting a `concat_fragment`/`concat::fragment` with a descriptive tag to PuppetDB for each CA certificate they are responsible for. A random manifest then can realize a `concat_file`/`concat` gathering a list of tags (e.g. `['cacert_intermediate_2', 'cacert_intermediate_1', 'cacert_root']`).  
Actually that was my initial use case when I was patching the native types many years ago and I'm running these patches for years now ;). Time to contribute!

I kept the original behavior of the defined types by making the `tag` parameter(s) optional and stick with the current default(s) if not used. That way it's a bare feature addition that shouldn't break any scenario out there.