### PR TITLE
(CAT-1692) - Compatibility fix with puppet 7.14

### DIFF
--- a/lib/puppet/type/concat_file.rb
+++ b/lib/puppet/type/concat_file.rb
@@ -297,7 +297,7 @@ Puppet::Type.newtype(:concat_file) do
   def fragment_content(r)
     if r[:content].nil? == false
       # Explicitly resolve deferred values.
-      fragment_content = r[:content].instance_of?(Puppet::Pops::Evaluator::DeferredValue) ? r[:content].resolve : r[:content]
+      fragment_content = r[:content].respond_to?(:resolve) ? r[:content].resolve : r[:content]
     elsif r[:source].nil? == false
       @source = nil
       Array(r[:source]).each do |source|


### PR DESCRIPTION
## Summary

Changes introduced as part of https://github.com/puppetlabs/puppetlabs-concat/pull/789 causing regression with puppet 7.14.


## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-concat/issues/803

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)