### PR TITLE
Reinstate ubuntu-20.04 as the github action runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
+    with:
+      runs_on: "ubuntu-20.04"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,3 +14,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
+    with:
+      runs_on: "ubuntu-20.04"


### PR DESCRIPTION
## Summary
Reinstate ubuntu-20.04 as the github actions runner image. 

## Additional Context
This is done because Centos-7, OracleLinux-7 and Scientific-7 are not getting provisioned on the ubuntu-2204 github runner image resulting in nightly job failures: https://github.com/puppetlabs/puppetlabs-concat/actions/runs/11395101272. It might be due to the EOL status of EL-7.

## Related Issues (if any)


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)