### PR TITLE
(CAT-2353) Puppetcore update

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,6 @@ fixtures:
     provision: 'https://github.com/puppetlabs/provision.git'
     puppet_agent:
       repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-      ref: v4.21.0
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
   symlinks:
     concat: '#{source_dir}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,13 @@ on:
 jobs:
   Spec:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
+    with:
+      flags: "--nightly"
     secrets: "inherit"
 
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: "--nightly"
     secrets: "inherit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,3 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
-    with:
-      runs_on: "ubuntu-24.04"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,5 +14,3 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     secrets: "inherit"
-    with:
-      runs_on: "ubuntu-24.04"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,9 @@
+--fail-on-warnings
 --relative
+--no-80chars-check
+--no-140chars-check
+--no-class_inherits_from_params_class-check
+--no-autoloader_layout-check
+--no-documentation-check
+--no-single_quote_string_with_variables-check
+--ignore-paths=.vendor/**/*.pp,.bundle/**/*.pp,pkg/**/*.pp,spec/**/*.pp,tests/**/*.pp,types/**/*.pp,vendor/**/*.pp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 AllCops:
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: '2.6'
+  TargetRubyVersion: 3.1
   Include:
   - "**/*.rb"
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -1,65 +1,86 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# frozen_string_literal: true
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+# For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
+gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN']
+  'https://rubygems-puppetcore.puppet.com'
+else
+  ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+end
+source gemsource_default
 
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+def location_for(place_or_constraint, fake_constraint = nil, opts = {})
+  git_url_regex  = /\A(?<url>(?:https?|git)[:@][^#]*)(?:#(?<branch>.*))?/
+  file_url_regex = %r{\Afile://(?<path>.*)}
+
+  if place_or_constraint && (git_url = place_or_constraint.match(git_url_regex))
+    # Git source → ignore :source, keep fake_constraint
+    [fake_constraint, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+
+  elsif place_or_constraint && (file_url = place_or_constraint.match(file_url_regex))
+    # File source → ignore :source, keep fake_constraint or default >= 0
+    [fake_constraint || '>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+
   else
-    [place_or_version, { require: false }]
+    # Plain version constraint → merge opts (including :source if provided)
+    [place_or_constraint, { require: false }.merge(opts)]
+  end
+end
+
+# Print debug information if DEBUG_GEMS or VERBOSE is set
+def print_gem_statement_for(gems)
+  puts 'DEBUG: Gem definitions that will be generated:'
+  gems.each do |gem_name, gem_params|
+    puts "DEBUG:   gem #{([gem_name.inspect] + gem_params.map(&:inspect)).join(', ')}"
   end
 end
 
 group :development do
-  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 2.1',                      require: false
+  gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "metadata-json-lint", '~> 4.0',            require: false
-  gem "rspec-puppet-facts", '~> 4.0',            require: false
+  gem "json-schema", '< 5.1.1',                  require: false
+  gem "rspec-puppet-facts", '~> 4.0',            require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rspec-puppet-facts", '~> 5.0',            require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.9',             require: false
-  gem "puppet-debugger", '~> 1.0',               require: false
+  gem "puppet-debugger", '~> 1.6',               require: false
   gem "rubocop", '~> 1.50.0',                    require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "rexml", '>= 3.3.9',                       require: false
+  gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 7.0', require: false
+  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
+  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end
 
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
-
 gems = {}
+puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
+facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
+hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-gems['puppet'] = location_for(puppet_version)
+gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
+gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
+gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version
 
-# If facter or hiera versions have been specified via the environment
-# variables
-
-gems['facter'] = location_for(facter_version) if facter_version
-gems['hiera'] = location_for(hiera_version) if hiera_version
-
+# Generate the gem definitions
+print_gem_statement_for(gems) if ENV['DEBUG']
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params
 end
@@ -67,12 +88,14 @@ end
 # Evaluate Gemfile.local and ~/.gemfile if they exist
 extra_gemfiles = [
   "#{__FILE__}.local",
-  File.join(Dir.home, '.gemfile'),
+  File.join(Dir.home, '.gemfile')
 ]
 
 extra_gemfiles.each do |gemfile|
-  if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
-  end
+  next unless File.file?(gemfile) && File.readable?(gemfile)
+
+  # rubocop:disable Security/Eval
+  eval(File.read(gemfile), binding)
+  # rubocop:enable Security/Eval
 end
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,12 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
 PuppetLint.configuration.send('disable_relative')
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_autoloader_layout')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]
+

--- a/metadata.json
+++ b/metadata.json
@@ -104,7 +104,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",

--- a/metadata.json
+++ b/metadata.json
@@ -108,6 +108,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "tags/3.2.0.4-0-g5d17ec1",
-  "pdk-version": "3.2.0"
+  "template-ref": "heads/main-0-g9d5b193",
+  "pdk-version": "3.5.0"
 }

--- a/spec/defines/concat_fragment_spec.rb
+++ b/spec/defines/concat_fragment_spec.rb
@@ -61,7 +61,7 @@ describe 'concat::fragment' do
   context 'when content =>' do
     ['', 'ashp is our hero'].each do |content|
       context content do
-        it_behaves_like 'fragment', 'motd_header', content: content,
+        it_behaves_like 'fragment', 'motd_header', content:,
                                                    target: '/etc/motd'
       end
     end
@@ -69,10 +69,10 @@ describe 'concat::fragment' do
     context 'when Sensitive' do
       let(:title) { 'authentication' }
       let(:content) { sensitive('password') }
-      let(:params) { { content: content, target: '/etc/authentication' } }
+      let(:params) { { content:, target: '/etc/authentication' } }
 
       it do
-        expect(subject).to contain_concat_fragment(title).with(content: content)
+        expect(subject).to contain_concat_fragment(title).with(content:)
       end
     end
 
@@ -90,7 +90,7 @@ describe 'concat::fragment' do
   context 'when source =>' do
     ['', '/foo/bar', ['/foo/bar', '/foo/baz']].each do |source|
       context source do
-        it_behaves_like 'fragment', 'motd_header',           source: source,
+        it_behaves_like 'fragment', 'motd_header',           source:,
                                                              target: '/etc/motd'
       end
     end
@@ -109,7 +109,7 @@ describe 'concat::fragment' do
   context 'when order =>' do
     ['', '42', 'a', 'z'].each do |order|
       context "'#{order}'" do
-        it_behaves_like 'fragment', 'motd_header',           order: order,
+        it_behaves_like 'fragment', 'motd_header',           order:,
                                                              target: '/etc/motd'
       end
     end

--- a/spec/defines/concat_spec.rb
+++ b/spec/defines/concat_spec.rb
@@ -44,7 +44,7 @@ describe 'concat' do
     let(:params) { params }
     let(:facts) do
       {
-        id: id,
+        id:,
         osfamily: 'Debian',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         kernel: 'Linux',
@@ -139,7 +139,7 @@ describe 'concat' do
     ['./foo', 'foo', 'foo/bar'].each do |path|
       context path do
         let(:title) { '/etc/foo.bar' }
-        let(:params) { { path: path } }
+        let(:params) { { path: } }
 
         it 'fails' do
           expect { catalogue }.to raise_error(Puppet::Error, %r{Stdlib::Unixpath})
@@ -152,7 +152,7 @@ describe 'concat' do
   context 'when owner =>' do
     ['apenney', 1000, '1001'].each do |owner|
       context owner do
-        it_behaves_like 'concat', '/etc/foo.bar', owner: owner
+        it_behaves_like 'concat', '/etc/foo.bar', owner:
       end
     end
 
@@ -170,7 +170,7 @@ describe 'concat' do
   context 'when group =>' do
     ['apenney', 1000, '1001'].each do |group|
       context group do
-        it_behaves_like 'concat', '/etc/foo.bar', group: group
+        it_behaves_like 'concat', '/etc/foo.bar', group:
       end
     end
 
@@ -204,14 +204,14 @@ describe 'concat' do
   context 'when warn =>' do
     [true, false, '# foo'].each do |warn|
       context warn do
-        it_behaves_like 'concat', '/etc/foo.bar', warn: warn
+        it_behaves_like 'concat', '/etc/foo.bar', warn:
       end
     end
 
     context 'when (stringified boolean)' do
       ['true', 'yes', 'on', 'false', 'no', 'off'].each do |warn|
         define warn do
-          it_behaves_like 'concat', '/etc/foo.bar', warn: warn
+          it_behaves_like('concat', '/etc/foo.bar', warn:)
 
           it 'creates a warning' do
             skip('rspec-puppet support for testing warning()')
@@ -234,7 +234,7 @@ describe 'concat' do
   context 'when show_diff =>' do
     [true, false].each do |show_diff|
       context show_diff do
-        it_behaves_like 'concat', '/etc/foo.bar', show_diff: show_diff
+        it_behaves_like 'concat', '/etc/foo.bar', show_diff:
       end
     end
 
@@ -252,7 +252,7 @@ describe 'concat' do
   context 'when backup =>' do
     ['reverse', false, true].each do |backup|
       context backup.to_s do
-        it_behaves_like 'concat', '/etc/foo.bar', backup: backup
+        it_behaves_like 'concat', '/etc/foo.bar', backup:
       end
     end
 
@@ -270,7 +270,7 @@ describe 'concat' do
   context 'when replace =>' do
     [true, false].each do |replace|
       context replace do
-        it_behaves_like 'concat', '/etc/foo.bar', replace: replace
+        it_behaves_like 'concat', '/etc/foo.bar', replace:
       end
     end
 
@@ -288,7 +288,7 @@ describe 'concat' do
   context 'when force =>' do
     [true, false].each do |force|
       context force do
-        it_behaves_like 'concat', '/etc/foo.bar', force: force
+        it_behaves_like 'concat', '/etc/foo.bar', force:
       end
     end
 
@@ -306,7 +306,7 @@ describe 'concat' do
   context 'when order =>' do
     ['alpha', 'numeric'].each do |order|
       context order do
-        it_behaves_like 'concat', '/etc/foo.bar', order: order
+        it_behaves_like 'concat', '/etc/foo.bar', order:
       end
     end
 
@@ -324,7 +324,7 @@ describe 'concat' do
   context 'when ensure_newline =>' do
     [true, false].each do |ensure_newline|
       context 'when true' do
-        it_behaves_like 'concat', '/etc/foo.bar', ensure_newline: ensure_newline
+        it_behaves_like 'concat', '/etc/foo.bar', ensure_newline:
       end
     end
 


### PR DESCRIPTION
A set of changes dedicated to implementing puppetcore into our modules. This update, amongst other changes, removes Puppet 7 support.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
