### PR TITLE
[MODULES-11646] use nightly build for acceptance tests 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,4 +13,6 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: '--nightly'
     secrets: "inherit"


### PR DESCRIPTION
## Summary
**CI workflow updates:**
* Added the `--nightly` flag to the `Acceptance` job in `.github/workflows/nightly.yml` for improved clarity and explicitness in nightly test runs.

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)