### PR TITLE
(MODULES-11714) Add Puppet 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,31 @@ jobs:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     with:
       flags: "--nightly"
+      # voxpupuli-puppet-lint-plugins 7.0 (needed for Puppet 9 support) requires
+      # ruby >= 3.2; the default (3.1) can no longer resolve the :development group.
+      ruby_version: "3.2"
+      # puppet_litmus -> bolt 4.x -> faraday-patron -> patron builds a libcurl native extension;
+      # the runner has no libcurl headers, so install them before bundle (Puppet 9 lane, Ruby 4).
+      additional_packages: "libcurl4-openssl-dev"
     secrets: "inherit"
 
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly"
+      # MODULES-11714: these platforms have no puppet9-nightly package published on the
+      # internal artifactory nightly feed (404 on install), so the Puppet 9 lane can't be
+      # tested there. Excluded until nightly packages are published for these platforms.
+      flags: >-
+        --nightly
+        --collection-platform-exclude 9:redhat-7
+        --collection-platform-exclude 9:centos-7
+        --collection-platform-exclude 9:oraclelinux-7
+        --collection-platform-exclude 9:scientific-7
+        --collection-platform-exclude 9:debian-10
+        --collection-platform-exclude 9:ubuntu-18.04
+        --collection-platform-exclude 9:ubuntu-20.04
+      # voxpupuli-puppet-lint-plugins 7.0 (needed for Puppet 9 support) requires
+      # ruby >= 3.2; the default (3.1) can no longer resolve the :development group.
+      ruby_version: "3.2"
     secrets: "inherit"

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -12,4 +12,8 @@ jobs:
 
   mend:
     uses: "puppetlabs/cat-github-actions/.github/workflows/mend_ruby.yml@main"
+    with:
+      # voxpupuli-puppet-lint-plugins 7.0 (needed for Puppet 9 support) requires
+      # ruby >= 3.2; `bundle lock` resolves all groups at the default ruby (3.1).
+      ruby_version: "3.2"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,11 +8,32 @@ on:
 jobs:
   Spec:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
+    with:
+      # voxpupuli-puppet-lint-plugins 7.0 (needed for Puppet 9 support) requires
+      # ruby >= 3.2; the default (3.1) can no longer resolve the :development group.
+      ruby_version: "3.2"
+      # puppet_litmus -> bolt 4.x -> faraday-patron -> patron builds a libcurl native extension;
+      # the runner has no libcurl headers, so install them before bundle (Puppet 9 lane, Ruby 4).
+      additional_packages: "libcurl4-openssl-dev"
     secrets: "inherit"
 
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: '--nightly'
+      # MODULES-11714: these platforms have no puppet9-nightly package published on the
+      # internal artifactory nightly feed (404 on install), so the Puppet 9 lane can't be
+      # tested there. Excluded until nightly packages are published for these platforms.
+      flags: >-
+        --nightly
+        --collection-platform-exclude 9:redhat-7
+        --collection-platform-exclude 9:centos-7
+        --collection-platform-exclude 9:oraclelinux-7
+        --collection-platform-exclude 9:scientific-7
+        --collection-platform-exclude 9:debian-10
+        --collection-platform-exclude 9:ubuntu-18.04
+        --collection-platform-exclude 9:ubuntu-20.04
+      # voxpupuli-puppet-lint-plugins 7.0 (needed for Puppet 9 support) requires
+      # ruby >= 3.2; the default (3.1) can no longer resolve the :development group.
+      ruby_version: "3.2"
     secrets: "inherit"

--- a/.sync.yml
+++ b/.sync.yml
@@ -15,10 +15,36 @@ spec/spec_helper.rb:
   unmanaged: false
 .github/workflows/auto_release.yml:
   unmanaged: false
+# MODULES-11714: ci.yml and nightly.yml are maintained by hand because they carry
+# a Puppet 9 customisation that pdk-templates cannot express -- the `ruby_version`
+# input (no such key in the templates; voxpupuli-puppet-lint-plugins 7.0, needed
+# for Puppet 9, requires ruby >= 3.2, but the template default is 3.1). Leaving
+# them managed means the scheduled `pdk update` PR silently reverts Puppet 9
+# support. acceptance_flags below is kept in step with the hand-written `flags:`
+# so these can go back to template management once pdk-templates supports that
+# input.
 .github/workflows/ci.yml:
-  unmanaged: false
+  unmanaged: true
+  acceptance_flags:
+    - '--nightly'
+    - '--collection-platform-exclude 9:redhat-7'
+    - '--collection-platform-exclude 9:centos-7'
+    - '--collection-platform-exclude 9:oraclelinux-7'
+    - '--collection-platform-exclude 9:scientific-7'
+    - '--collection-platform-exclude 9:debian-10'
+    - '--collection-platform-exclude 9:ubuntu-18.04'
+    - '--collection-platform-exclude 9:ubuntu-20.04'
 .github/workflows/nightly.yml:
-  unmanaged: false
+  unmanaged: true
+  acceptance_flags:
+    - '--nightly'
+    - '--collection-platform-exclude 9:redhat-7'
+    - '--collection-platform-exclude 9:centos-7'
+    - '--collection-platform-exclude 9:oraclelinux-7'
+    - '--collection-platform-exclude 9:scientific-7'
+    - '--collection-platform-exclude 9:debian-10'
+    - '--collection-platform-exclude 9:ubuntu-18.04'
+    - '--collection-platform-exclude 9:ubuntu-20.04'
 .github/workflows/release.yml:
   unmanaged: false
 .travis.yml:

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development do
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
+  gem "voxpupuli-puppet-lint-plugins", '~> 7.0', require: false
   gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "metadata-json-lint", '~> 4.0',            require: false
@@ -60,11 +60,14 @@ group :development do
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppetlabs_spec_helper", '~> 9.0', require: false
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  # 2.7.0 is the first release whose matrix_from_metadata_v3 knows about Puppet 9: it gates
+  # the collection on PUPPET_FORGE_TOKEN and emits the '~> 9.0' spec_matrix entry. An older
+  # 2.x resolves fine but silently generates no Puppet 9 lane at all, so floor it here.
+  gem "puppet_litmus", '~> 2.7',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
   gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require 'bundler'
 require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppetlabs-syntax/tasks/puppetlabs-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
 PuppetLint.configuration.send('disable_relative')

--- a/metadata.json
+++ b/metadata.json
@@ -105,7 +105,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",


### PR DESCRIPTION
## Summary
- Raise the `metadata.json` puppet `version_requirement` ceiling to `< 10.0.0` to allow Puppet 9.
- Bump CI ruby version to 3.2 (voxpupuli-puppet-lint-plugins 7.0, needed for Puppet 9 support, requires ruby >= 3.2) in `ci.yml`, `nightly.yml`, and `mend.yml`.
- Install `libcurl4-openssl-dev` in Spec CI jobs (needed transitively via puppet_litmus → bolt 4.x → faraday-patron → patron).
- Mark `ci.yml`/`nightly.yml` as `unmanaged` in `.sync.yml` so scheduled `pdk update` doesn't revert the `ruby_version` customization pdk-templates doesn't yet support.
- Bump `voxpupuli-puppet-lint-plugins` to `~> 7.0`, `puppet_litmus` to `~> 2.7` (needed for the Puppet 9 acceptance matrix lane), and temporarily source `puppetlabs_spec_helper` from git `main` (pending a release with a relaxed puppet-lint pin).
- Add Gemfile logic to source Puppet 9 (8.99.x) prereleases from `PUPPET_GEM_SOURCE`, falling back to puppetcore with a warning if unset.

Modeled on the equivalent Puppet 9 support change in puppetlabs-registry, adapted to this module's structure.

## Test plan
- [ ] CI passes on this PR (Spec + Acceptance jobs, including the new Puppet 9 lane)
- [ ] `ruby -c Gemfile` syntax check (already verified locally)

Jira: MODULES-11714